### PR TITLE
Add support for numeric type „integer“

### DIFF
--- a/pkg/codegen/utils.go
+++ b/pkg/codegen/utils.go
@@ -30,6 +30,8 @@ func PrimitiveTypeFromJSONSchemaType(jsType string) (Type, error) {
 		return PrimitiveType{"string"}, nil
 	case schemas.TypeNameNumber:
 		return PrimitiveType{"float64"}, nil
+	case schemas.TypeNameInteger:
+		return PrimitiveType{"int"}, nil
 	case schemas.TypeNameBoolean:
 		return PrimitiveType{"bool"}, nil
 	case schemas.TypeNameNull:

--- a/pkg/schemas/types.go
+++ b/pkg/schemas/types.go
@@ -4,6 +4,7 @@ const (
 	TypeNameString  = "string"
 	TypeNameArray   = "array"
 	TypeNameNumber  = "number"
+	TypeNameInteger = "integer"
 	TypeNameObject  = "object"
 	TypeNameBoolean = "boolean"
 	TypeNameNull    = "null"
@@ -11,7 +12,7 @@ const (
 
 func IsPrimitiveType(t string) bool {
 	switch t {
-	case TypeNameString, TypeNameNumber, TypeNameBoolean, TypeNameNull:
+	case TypeNameString, TypeNameNumber, TypeNameInteger, TypeNameBoolean, TypeNameNull:
 		return true
 	default:
 		return false

--- a/tests/data/core/4.2.1_array.go.output
+++ b/tests/data/core/4.2.1_array.go.output
@@ -8,6 +8,9 @@ type A421Array struct {
 	// MyBooleanArray corresponds to the JSON schema field "myBooleanArray".
 	MyBooleanArray []bool `json:"myBooleanArray,omitempty"`
 
+	// MyIntegerArray corresponds to the JSON schema field "myIntegerArray".
+	MyIntegerArray []int `json:"myIntegerArray,omitempty"`
+
 	// MyNullArray corresponds to the JSON schema field "myNullArray".
 	MyNullArray []interface{} `json:"myNullArray,omitempty"`
 

--- a/tests/data/core/4.2.1_array.json
+++ b/tests/data/core/4.2.1_array.json
@@ -15,6 +15,12 @@
         "type": "number"
       }
     },
+    "myIntegerArray": {
+      "type": "array",
+      "items": {
+        "type": "integer"
+      }
+    },
     "myBooleanArray": {
       "type": "array",
       "items": {

--- a/tests/data/core/primitives.go.output
+++ b/tests/data/core/primitives.go.output
@@ -6,6 +6,9 @@ type Primitives struct {
 	// MyBoolean corresponds to the JSON schema field "myBoolean".
 	MyBoolean *bool `json:"myBoolean,omitempty"`
 
+	// MyInteger corresponds to the JSON schema field "myInteger".
+	MyInteger *int `json:"myInteger,omitempty"`
+
 	// MyNull corresponds to the JSON schema field "myNull".
 	MyNull interface{} `json:"myNull,omitempty"`
 

--- a/tests/data/core/primitives.json
+++ b/tests/data/core/primitives.json
@@ -9,6 +9,9 @@
     "myNumber": {
       "type": "number"
     },
+    "myInteger": {
+      "type": "integer"
+    },
     "myBoolean": {
       "type": "boolean"
     },

--- a/tests/data/validation/6.1.2_enum.go.output
+++ b/tests/data/validation/6.1.2_enum.go.output
@@ -33,6 +33,34 @@ func (j *A612EnumMyBooleanTypedEnum) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
+type A612EnumMyIntegerTypedEnum int
+
+var enumValues_A612EnumMyIntegerTypedEnum = []interface{}{
+	1,
+	2,
+	3,
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *A612EnumMyIntegerTypedEnum) UnmarshalJSON(b []byte) error {
+	var v int
+	if err := json.Unmarshal(b, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_A612EnumMyIntegerTypedEnum {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_A612EnumMyIntegerTypedEnum, v)
+	}
+	*j = A612EnumMyIntegerTypedEnum(v)
+	return nil
+}
+
 type A612EnumMyMixedUntypedEnum struct {
 	Value interface{}
 }
@@ -106,34 +134,6 @@ func (j *A612EnumMyNullTypedEnum) UnmarshalJSON(b []byte) error {
 	return nil
 }
 
-type A612EnumMyNumberTypedEnum float64
-
-var enumValues_A612EnumMyNumberTypedEnum = []interface{}{
-	1,
-	2,
-	3,
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *A612EnumMyNumberTypedEnum) UnmarshalJSON(b []byte) error {
-	var v float64
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_A612EnumMyNumberTypedEnum {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_A612EnumMyNumberTypedEnum, v)
-	}
-	*j = A612EnumMyNumberTypedEnum(v)
-	return nil
-}
-
 type A612EnumMyStringTypedEnum string
 
 var enumValues_A612EnumMyStringTypedEnum = []interface{}{
@@ -174,6 +174,9 @@ type A612Enum struct {
 	// "myBooleanUntypedEnum".
 	MyBooleanUntypedEnum *A612EnumMyBooleanTypedEnum `json:"myBooleanUntypedEnum,omitempty"`
 
+	// MyIntegerTypedEnum corresponds to the JSON schema field "myIntegerTypedEnum".
+	MyIntegerTypedEnum *A612EnumMyIntegerTypedEnum `json:"myIntegerTypedEnum,omitempty"`
+
 	// MyMixedUntypedEnum corresponds to the JSON schema field "myMixedUntypedEnum".
 	MyMixedUntypedEnum *A612EnumMyMixedUntypedEnum `json:"myMixedUntypedEnum,omitempty"`
 
@@ -184,10 +187,10 @@ type A612Enum struct {
 	MyNullUntypedEnum *A612EnumMyNullTypedEnum `json:"myNullUntypedEnum,omitempty"`
 
 	// MyNumberTypedEnum corresponds to the JSON schema field "myNumberTypedEnum".
-	MyNumberTypedEnum *A612EnumMyNumberTypedEnum `json:"myNumberTypedEnum,omitempty"`
+	MyNumberTypedEnum *A612EnumMyIntegerTypedEnum `json:"myNumberTypedEnum,omitempty"`
 
 	// MyNumberUntypedEnum corresponds to the JSON schema field "myNumberUntypedEnum".
-	MyNumberUntypedEnum *A612EnumMyNumberTypedEnum `json:"myNumberUntypedEnum,omitempty"`
+	MyNumberUntypedEnum *A612EnumMyIntegerTypedEnum `json:"myNumberUntypedEnum,omitempty"`
 
 	// MyStringTypedEnum corresponds to the JSON schema field "myStringTypedEnum".
 	MyStringTypedEnum *A612EnumMyStringTypedEnum `json:"myStringTypedEnum,omitempty"`

--- a/tests/data/validation/6.1.2_enum.json
+++ b/tests/data/validation/6.1.2_enum.json
@@ -27,6 +27,10 @@
       "type": "number",
       "enum": [1, 2, 3]
     },
+    "myIntegerTypedEnum": {
+      "type": "integer",
+      "enum": [1, 2, 3]
+    },
     "myBooleanTypedEnum": {
       "type": "boolean",
       "enum": [true, false]

--- a/tests/data/validation/6.5.3_requiredFields.go.output
+++ b/tests/data/validation/6.5.3_requiredFields.go.output
@@ -60,6 +60,12 @@ type A653RequiredFields struct {
 	// MyBooleanArray corresponds to the JSON schema field "myBooleanArray".
 	MyBooleanArray []bool `json:"myBooleanArray"`
 
+	// MyInteger corresponds to the JSON schema field "myInteger".
+	MyInteger *int `json:"myInteger,omitempty"`
+
+	// MyIntegerArray corresponds to the JSON schema field "myIntegerArray".
+	MyIntegerArray []int `json:"myIntegerArray,omitempty"`
+
 	// MyNull corresponds to the JSON schema field "myNull".
 	MyNull interface{} `json:"myNull"`
 

--- a/tests/data/validation/6.5.3_requiredFields.json
+++ b/tests/data/validation/6.5.3_requiredFields.json
@@ -21,6 +21,9 @@
     "myNumber": {
       "type": "number"
     },
+    "myInteger": {
+      "type": "integer"
+    },
     "myBoolean": {
       "type": "boolean"
     },
@@ -47,6 +50,12 @@
       "type": "array",
       "items": {
         "type": "number"
+      }
+    },
+    "myIntegerArray": {
+      "type": "array",
+      "items": {
+        "type": "integer"
       }
     },
     "myBooleanArray": {


### PR DESCRIPTION
Added support for the common "integer" type in addition to "number" type.
If could be considered to use int64 instead in the future. Not sure yet how the exact definition in terms if bitsize for integer types in JSON schema are. For now however, it seems to work fine.
This should close issue #2 