### PR TITLE
Use float64 for minimum type because it's "number"

### DIFF
--- a/pkg/schemas/model.go
+++ b/pkg/schemas/model.go
@@ -75,7 +75,7 @@ type Type struct {
 	MultipleOf           int              `json:"multipleOf,omitempty"`           // section 5.1
 	Maximum              int              `json:"maximum,omitempty"`              // section 5.2
 	ExclusiveMaximum     bool             `json:"exclusiveMaximum,omitempty"`     // section 5.3
-	Minimum              int              `json:"minimum,omitempty"`              // section 5.4
+	Minimum              float64          `json:"minimum,omitempty"`              // section 5.4
 	ExclusiveMinimum     bool             `json:"exclusiveMinimum,omitempty"`     // section 5.5
 	MaxLength            int              `json:"maxLength,omitempty"`            // section 5.6
 	MinLength            int              `json:"minLength,omitempty"`            // section 5.7

--- a/pkg/schemas/model.go
+++ b/pkg/schemas/model.go
@@ -73,7 +73,7 @@ type Type struct {
 	Ref     string `json:"$ref,omitempty"`    // section 7
 	// RFC draft-wright-json-schema-validation-00, section 5
 	MultipleOf           int              `json:"multipleOf,omitempty"`           // section 5.1
-	Maximum              int              `json:"maximum,omitempty"`              // section 5.2
+	Maximum              float64          `json:"maximum,omitempty"`              // section 5.2
 	ExclusiveMaximum     bool             `json:"exclusiveMaximum,omitempty"`     // section 5.3
 	Minimum              float64          `json:"minimum,omitempty"`              // section 5.4
 	ExclusiveMinimum     bool             `json:"exclusiveMinimum,omitempty"`     // section 5.5


### PR DESCRIPTION
> The value of "minimum" MUST be a number, representing an inclusive lower
> limit for a numeric instance.

http://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.2.4

I couldn't use this go-jsonschema to generate files for https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/schemas/sarif-schema-2.1.0.json because it uses minimum as float (number) value.