### PR TITLE
feat: add 'additionalProperties' for map with single type prop 

### DIFF
--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -575,9 +575,16 @@ func (g *schemaGenerator) generateStructType(
 			g.warner("Object type with no properties has required fields; " +
 				"skipping validation code for them since we don't know their types")
 		}
+		valueType := codegen.Type(codegen.EmptyInterfaceType{})
+		var err error
+		if t.AdditionalProperties != nil {
+			if valueType, err = g.generateType(t.AdditionalProperties, nil); err != nil {
+				return nil, err
+			}
+		}
 		return &codegen.MapType{
 			KeyType:   codegen.PrimitiveType{Type: "string"},
-			ValueType: codegen.EmptyInterfaceType{},
+			ValueType: valueType,
 		}, nil
 	}
 

--- a/pkg/schemas/model.go
+++ b/pkg/schemas/model.go
@@ -90,7 +90,7 @@ type Type struct {
 	Required             []string         `json:"required,omitempty"`             // section 5.15
 	Properties           map[string]*Type `json:"properties,omitempty"`           // section 5.16
 	PatternProperties    map[string]*Type `json:"patternProperties,omitempty"`    // section 5.17
-	AdditionalProperties json.RawMessage  `json:"additionalProperties,omitempty"` // section 5.18
+	AdditionalProperties *Type            `json:"additionalProperties,omitempty"` // section 5.18
 	Dependencies         map[string]*Type `json:"dependencies,omitempty"`         // section 5.19
 	Enum                 []interface{}    `json:"enum,omitempty"`                 // section 5.20
 	Type                 TypeList         `json:"type,omitempty"`                 // section 5.21


### PR DESCRIPTION
Hello!
I wanted to construct a typed map with `additionalProperties`. Just like this schema:
```
{
	"id": "https://github/test",
	"type": "object",
	"properties": {
		"itemType": {
			"$ref": "#/definitions/mapInt"
		},
		"itemCount": {
			"$ref": "#/definitions/mapInt"
		}
	},
	"definitions": {
		"mapInt": {
			"type": "object",
			"additionalProperties": {
				"type": "integer"
			}
		}
	}
}
```
And it should be generated like this:
```
type MapInt map[string]int

type TestJson struct {
	// ItemCount corresponds to the JSON schema field "itemCount".
	ItemCount MapInt `json:"itemCount,omitempty"`

	// ItemType corresponds to the JSON schema field "itemType".
	ItemType MapInt `json:"itemType,omitempty"`
}
```
This change worked for me very well. Do I need to create another unit test for this?
Thanks.