### PR TITLE
Fix multiple interfaces for enum appearing from multiple references to it

### DIFF
--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -789,6 +789,7 @@ func (g *schemaGenerator) generateEnumType(
 	g.output.file.Package.AddDecl(&enumDecl)
 
 	g.output.declsByName[enumDecl.Name] = &enumDecl
+	g.output.declsBySchema[t] = &enumDecl
 
 	valueConstant := &codegen.Var{
 		Name:  "enumValues_" + enumDecl.Name,

--- a/tests/data/core/refToEnum.go.output
+++ b/tests/data/core/refToEnum.go.output
@@ -35,38 +35,8 @@ func (j *Thing) UnmarshalJSON(b []byte) error {
 
 type RefToEnum struct {
 	// MyThing corresponds to the JSON schema field "myThing".
-	MyThing *Thing_1 `json:"myThing,omitempty" yaml:"myThing,omitempty"`
+	MyThing *Thing `json:"myThing,omitempty" yaml:"myThing,omitempty"`
 }
 
 const ThingX Thing = "x"
-
-type Thing_1 string
-
-var enumValues_Thing_1 = []interface{}{
-	"x",
-	"y",
-}
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (j *Thing_1) UnmarshalJSON(b []byte) error {
-	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
-		return err
-	}
-	var ok bool
-	for _, expected := range enumValues_Thing_1 {
-		if reflect.DeepEqual(v, expected) {
-			ok = true
-			break
-		}
-	}
-	if !ok {
-		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_Thing_1, v)
-	}
-	*j = Thing_1(v)
-	return nil
-}
-
 const ThingY Thing = "y"
-const Thing_1_X Thing_1 = "x"
-const Thing_1_Y Thing_1 = "y"


### PR DESCRIPTION
Track enum declarations by schema type like it's done for object types.

Fixes #17 .