### PR TITLE
Adds enforcing integer type for enum values

### DIFF
--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -981,6 +981,18 @@ func (g *schemaGenerator) generateEnumType(
 			return nil, fmt.Errorf("invalid type %q: %w", t.Type[0], err)
 		}
 
+		//Enforce integer type for enum values
+		if t.Type[0] == "integer" {
+			for i, v := range t.Enum {
+				switch v.(type) {
+				case float64:
+					t.Enum[i] = int(v.(float64))
+				default:
+					return nil, fmt.Errorf("%w %v", errEnumNonPrimitiveVal, v)
+				}
+			}
+		}
+
 		wrapInStruct = t.Type[0] == schemas.TypeNameNull // Null uses interface{}, which cannot have methods.
 	} else {
 		if len(t.Type) > 1 {

--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -981,12 +981,13 @@ func (g *schemaGenerator) generateEnumType(
 			return nil, fmt.Errorf("invalid type %q: %w", t.Type[0], err)
 		}
 
-		//Enforce integer type for enum values
+		// Enforce integer type for enum values.
 		if t.Type[0] == "integer" {
 			for i, v := range t.Enum {
-				switch v.(type) {
+				switch v := v.(type) {
 				case float64:
-					t.Enum[i] = int(v.(float64))
+					t.Enum[i] = int(v)
+
 				default:
 					return nil, fmt.Errorf("%w %v", errEnumNonPrimitiveVal, v)
 				}

--- a/tests/data/validation/6.1.2_enum.go.output
+++ b/tests/data/validation/6.1.2_enum.go.output
@@ -89,9 +89,9 @@ var enumValues_A612EnumMyBooleanUntypedEnum = []interface{}{
 	false,
 }
 var enumValues_A612EnumMyIntegerTypedEnum = []interface{}{
-	1.0,
-	2.0,
-	3.0,
+	1,
+	2,
+	3,
 }
 var enumValues_A612EnumMyMixedTypeEnum = []interface{}{
 	42.0,


### PR DESCRIPTION
Addressing the issue https://github.com/omissis/go-jsonschema/issues/102 

Enforcing `int` type for Enum values in case primitive type is set to `integer`