### PR TITLE
Only perform minItems validation when field is provided

### DIFF
--- a/pkg/generator/validator.go
+++ b/pkg/generator/validator.go
@@ -182,7 +182,7 @@ func (v *arrayValidator) generate(out *codegen.Emitter) {
 	}
 
 	if v.minItems != 0 {
-		out.Printlnf(`if len(%s) < %d {`, value, v.minItems)
+		out.Printlnf(`if %s != nil && len(%s) < %d {`, value, value, v.minItems)
 		out.Indent(1)
 		out.Printlnf(`return fmt.Errorf("field %%s length: must be >= %%d", %s, %d)`, fieldName, v.minItems)
 		out.Indent(-1)

--- a/tests/data/validation/5.11_minItems.go.output
+++ b/tests/data/validation/5.11_minItems.go.output
@@ -24,15 +24,15 @@ func (j *A511MinItems) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	if len(plain.MyNestedArray) < 5 {
+	if plain.MyNestedArray != nil && len(plain.MyNestedArray) < 5 {
 		return fmt.Errorf("field %s length: must be >= %d", "myNestedArray", 5)
 	}
 	for i1 := range plain.MyNestedArray {
-		if len(plain.MyNestedArray[i1]) < 5 {
+		if plain.MyNestedArray[i1] != nil && len(plain.MyNestedArray[i1]) < 5 {
 			return fmt.Errorf("field %s length: must be >= %d", fmt.Sprintf("myNestedArray[%d]", i1), 5)
 		}
 	}
-	if len(plain.MyStringArray) < 5 {
+	if plain.MyStringArray != nil && len(plain.MyStringArray) < 5 {
 		return fmt.Errorf("field %s length: must be >= %d", "myStringArray", 5)
 	}
 	*j = A511MinItems(plain)

--- a/tests/data/validation/5.1x_minMaxItems.go.output
+++ b/tests/data/validation/5.1x_minMaxItems.go.output
@@ -24,21 +24,21 @@ func (j *A51XMinMaxItems) UnmarshalJSON(b []byte) error {
 	if err := json.Unmarshal(b, &plain); err != nil {
 		return err
 	}
-	if len(plain.MyNestedArray) < 1 {
+	if plain.MyNestedArray != nil && len(plain.MyNestedArray) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "myNestedArray", 1)
 	}
 	if len(plain.MyNestedArray) > 5 {
 		return fmt.Errorf("field %s length: must be <= %d", "myNestedArray", 5)
 	}
 	for i1 := range plain.MyNestedArray {
-		if len(plain.MyNestedArray[i1]) < 1 {
+		if plain.MyNestedArray[i1] != nil && len(plain.MyNestedArray[i1]) < 1 {
 			return fmt.Errorf("field %s length: must be >= %d", fmt.Sprintf("myNestedArray[%d]", i1), 1)
 		}
 		if len(plain.MyNestedArray[i1]) > 5 {
 			return fmt.Errorf("field %s length: must be <= %d", fmt.Sprintf("myNestedArray[%d]", i1), 5)
 		}
 	}
-	if len(plain.MyStringArray) < 1 {
+	if plain.MyStringArray != nil && len(plain.MyStringArray) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "myStringArray", 1)
 	}
 	if len(plain.MyStringArray) > 3 {


### PR DESCRIPTION
As reported in #86, minItems validation is being applied even when a non-required field is omitted from the input json.

A json schema like
```json
{
  "$schema": "http://json-schema.org/draft-04/schema#",
  "id": "https://example.com/array",
  "type": "object",
  "properties": {
    "myArray": {
      "type": "array",
      "items": {
        "type": "string"
      },
      "minItems": 1,
      "maxItems": 3
    },
  }
}
```
should pass against an empty object input
```json
{}
```
(can be tested at https://www.jsonschemavalidator.net/)

Instead the generated code will result in an error during unmarshal. The proposed solution is to just add a `nil` check - non-required slices use `omitempty`, which means they end up `nil` if not supplied. If the field is required, the earlier field presence check will catch these - but also they'll never be `nil` because `omitempty` is not used under such circumstances. So overall this additional constraint seems safe to add. Happy to take direction on other approaches.