### PR TITLE
Correct definition of MultipleOf and ExclusiveMaximum. 

### DIFF
--- a/pkg/schemas/model.go
+++ b/pkg/schemas/model.go
@@ -112,9 +112,9 @@ type Type struct {
 	Version string `json:"$schema,omitempty"` // Section 6.1.
 	Ref     string `json:"$ref,omitempty"`    // Section 7.
 	// RFC draft-wright-json-schema-validation-00, section 5.
-	MultipleOf           int              `json:"multipleOf,omitempty"`           // Section 5.1.
+	MultipleOf           float64          `json:"multipleOf,omitempty"`           // Section 5.1.
 	Maximum              float64          `json:"maximum,omitempty"`              // Section 5.2.
-	ExclusiveMaximum     bool             `json:"exclusiveMaximum,omitempty"`     // Section 5.3.
+	ExclusiveMaximum     float64          `json:"exclusiveMaximum,omitempty"`     // Section 5.3.
 	Minimum              float64          `json:"minimum,omitempty"`              // Section 5.4.
 	ExclusiveMinimum     bool             `json:"exclusiveMinimum,omitempty"`     // Section 5.5.
 	MaxLength            int              `json:"maxLength,omitempty"`            // Section 5.6.

--- a/pkg/schemas/model.go
+++ b/pkg/schemas/model.go
@@ -116,7 +116,7 @@ type Type struct {
 	Maximum              float64          `json:"maximum,omitempty"`              // Section 5.2.
 	ExclusiveMaximum     float64          `json:"exclusiveMaximum,omitempty"`     // Section 5.3.
 	Minimum              float64          `json:"minimum,omitempty"`              // Section 5.4.
-	ExclusiveMinimum     bool             `json:"exclusiveMinimum,omitempty"`     // Section 5.5.
+	ExclusiveMinimum     float64          `json:"exclusiveMinimum,omitempty"`     // Section 5.5.
 	MaxLength            int              `json:"maxLength,omitempty"`            // Section 5.6.
 	MinLength            int              `json:"minLength,omitempty"`            // Section 5.7.
 	Pattern              string           `json:"pattern,omitempty"`              // Section 5.8.


### PR DESCRIPTION
- Correct definition of MultipleOf and ExclusiveMaximum. Both should be float64 according to http://json-schema.org/draft/2020-12/json-schema-validation.html#name-multipleof
- fix: set exclusiveMinimum to float64 as well
