### PR TITLE
enhance splitIdentifierByCaseAndSeparators to support non-case-sensitive languages

### DIFF
--- a/internal/x/text/cases.go
+++ b/internal/x/text/cases.go
@@ -47,7 +47,7 @@ func (c *Caser) Identifierize(s string) string {
 
 	rIdent := []rune(ident)
 	if len(rIdent) > 0 {
-		if !unicode.IsLetter(rIdent[0]) || isNoneCaseSensitiveLetter(rIdent[0]) {
+		if !unicode.IsLetter(rIdent[0]) || isNotCaseSensitiveLetter(rIdent[0]) {
 			ident = "A" + ident
 		}
 	}
@@ -55,7 +55,7 @@ func (c *Caser) Identifierize(s string) string {
 	return ident
 }
 
-func isNoneCaseSensitiveLetter(r rune) bool {
+func isNotCaseSensitiveLetter(r rune) bool {
 	return !unicode.IsUpper(r) && !unicode.IsLower(r)
 }
 
@@ -86,7 +86,7 @@ func splitIdentifierByCaseAndSeparators(s string) []string {
 		stateNothing state = iota
 		stateLower
 		stateUpper
-		stateNonCase
+		stateNoCase
 		stateNumber
 		stateDelimiter
 	)
@@ -114,7 +114,7 @@ func splitIdentifierByCaseAndSeparators(s string) []string {
 			nextState = stateDelimiter
 
 		default: // Non-case sensitive letters.
-			nextState = stateNonCase
+			nextState = stateNoCase
 		}
 
 		if nextState != currState {

--- a/internal/x/text/cases.go
+++ b/internal/x/text/cases.go
@@ -45,11 +45,18 @@ func (c *Caser) Identifierize(s string) string {
 
 	ident := sb.String()
 
-	if !unicode.IsLetter(rune(ident[0])) {
-		ident = "A" + ident
+	rIdent := []rune(ident)
+	if len(rIdent) > 0 {
+		if !unicode.IsLetter(rIdent[0]) || isNoneCaseSensitiveLetter(rIdent[0]) {
+			ident = "A" + ident
+		}
 	}
 
 	return ident
+}
+
+func isNoneCaseSensitiveLetter(r rune) bool {
+	return !unicode.IsUpper(r) && !unicode.IsLower(r)
 }
 
 func (c *Caser) Capitalize(s string) string {
@@ -63,7 +70,9 @@ func (c *Caser) Capitalize(s string) string {
 		}
 	}
 
-	return strings.ToUpper(s[0:1]) + s[1:]
+	r := []rune(s)
+
+	return string(unicode.ToUpper(r[0])) + string(r[1:])
 }
 
 func splitIdentifierByCaseAndSeparators(s string) []string {
@@ -77,31 +86,35 @@ func splitIdentifierByCaseAndSeparators(s string) []string {
 		stateNothing state = iota
 		stateLower
 		stateUpper
+		stateNonCase
 		stateNumber
 		stateDelimiter
 	)
 
-	var result []string
+	var result [][]rune
 
 	currState, j := stateNothing, 0
 
-	for i := 0; i < len(s); i++ {
+	runes := []rune(s)
+
+	for i, r := range runes {
 		var nextState state
 
-		c := rune(s[i])
-
 		switch {
-		case unicode.IsLower(c):
+		case unicode.IsLower(r):
 			nextState = stateLower
 
-		case unicode.IsUpper(c):
+		case unicode.IsUpper(r):
 			nextState = stateUpper
 
-		case unicode.IsNumber(c):
+		case unicode.IsNumber(r):
 			nextState = stateNumber
 
-		default:
+		case !unicode.IsLetter(r): // Non-letter characters.
 			nextState = stateDelimiter
+
+		default: // Non-case sensitive letters.
+			nextState = stateNonCase
 		}
 
 		if nextState != currState {
@@ -109,7 +122,7 @@ func splitIdentifierByCaseAndSeparators(s string) []string {
 				j = i
 			} else if !(currState == stateUpper && nextState == stateLower) {
 				if i > j {
-					result = append(result, s[j:i])
+					result = append(result, runes[j:i])
 				}
 				j = i
 			}
@@ -118,8 +131,17 @@ func splitIdentifierByCaseAndSeparators(s string) []string {
 		}
 	}
 
-	if currState != stateDelimiter && len(s)-j > 0 {
-		result = append(result, s[j:])
+	if currState != stateDelimiter && len(runes)-j > 0 {
+		result = append(result, runes[j:])
+	}
+
+	return runesToStrings(result)
+}
+
+func runesToStrings(runes [][]rune) []string {
+	result := make([]string, len(runes))
+	for i, r := range runes {
+		result[i] = string(r)
 	}
 
 	return result

--- a/tests/data/misc/capitalization/capitalization.go
+++ b/tests/data/misc/capitalization/capitalization.go
@@ -38,4 +38,16 @@ type Capitalization struct {
 
 	// URLSomething corresponds to the JSON schema field "url_something".
 	URLSomething *string `json:"url_something,omitempty" yaml:"url_something,omitempty" mapstructure:"url_something,omitempty"`
+
+	// Aアトリビュート corresponds to the JSON schema field "アトリビュート".
+	Aアトリビュート *string `json:"アトリビュート,omitempty" yaml:"アトリビュート,omitempty" mapstructure:"アトリビュート,omitempty"`
+
+	// A属性 corresponds to the JSON schema field "属性".
+	A属性 *string `json:"属性,omitempty" yaml:"属性,omitempty" mapstructure:"属性,omitempty"`
+
+	// A屬性 corresponds to the JSON schema field "屬性".
+	A屬性 *string `json:"屬性,omitempty" yaml:"屬性,omitempty" mapstructure:"屬性,omitempty"`
+
+	// A속성 corresponds to the JSON schema field "속성".
+	A속성 *string `json:"속성,omitempty" yaml:"속성,omitempty" mapstructure:"속성,omitempty"`
 }

--- a/tests/data/misc/capitalization/capitalization.json
+++ b/tests/data/misc/capitalization/capitalization.json
@@ -41,6 +41,19 @@
     },
     "html__": {
       "type": "string"
+    },
+
+    "속성": {
+      "type": "string"
+    },
+    "アトリビュート": {
+      "type": "string"
+    },
+    "属性": {
+      "type": "string"
+    },
+    "屬性": {
+      "type": "string"
     }
   }
 }


### PR DESCRIPTION
This PR includes modifications to the `splitIdentifierByCaseAndSeparators` function, aiming to extend its compatibility to non-case-sensitive languages such as Korean, Chinese, and Japanese, among others.

Key Points:
- It maintains the existing functionality for case-sensitive languages.
- It integrates support for languages lacking case distinction, ensuring accurate processing while preserving the fundamental logic of the function.

However, I faced difficulties in augmenting the test suite to include these new language scenarios. My limited experience with the current test structure hindered my ability to confidently implement new test cases for these languages.

In an attempt to modify the tests, I utilized the go-jsonschema binary, executing the following command:

```bash
./go-jsonschema --capitalization HtMl,ID,URL -p test tests/data/misc/capitalization/capitalization.json -o tests/data/misc/capitalization/capitalization.go
```

This process resulted in struct names being generated as CapitalizationJson instead of Capitalization. Consequently, I manually adjusted the names.

I am uncertain about the correctness of these steps and would greatly appreciate any advice or guidance. Your feedback or suggestions for improving this feature expansion and the addition of test cases would be invaluable. 

Thank you.