### PR TITLE
Fix non-nullable type with two options

### DIFF
--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -603,7 +603,9 @@ func (g *schemaGenerator) generateTypeInline(
 
 				typeIndex = i
 			}
-		} else if len(t.Type) > 1 {
+		}
+
+		if len(t.Type) > 1 && !typeShouldBePointer {
 			g.warner("Property has multiple types; will be represented as interface{} with no validation")
 
 			return codegen.EmptyInterfaceType{}, nil

--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -606,7 +606,7 @@ func (g *schemaGenerator) generateTypeInline(
 		}
 
 		if len(t.Type) > 1 && !typeShouldBePointer {
-			g.warner("Property has multiple types; will be represented as interface{} with no validation")
+			g.warner(fmt.Sprintf("Property %s has multiple types; will be represented as interface{} with no validation", scope))
 
 			return codegen.EmptyInterfaceType{}, nil
 		}

--- a/tests/data/validation/typeMultiple/typeMultiple.go
+++ b/tests/data/validation/typeMultiple/typeMultiple.go
@@ -15,4 +15,7 @@ type TypeMultiple struct {
 	// ArrayOfAllPrimitives corresponds to the JSON schema field
 	// "arrayOfAllPrimitives".
 	ArrayOfAllPrimitives []interface{} `json:"arrayOfAllPrimitives,omitempty" yaml:"arrayOfAllPrimitives,omitempty" mapstructure:"arrayOfAllPrimitives,omitempty"`
+
+	// OnlyTwoOptions corresponds to the JSON schema field "onlyTwoOptions".
+	OnlyTwoOptions interface{} `json:"onlyTwoOptions,omitempty" yaml:"onlyTwoOptions,omitempty" mapstructure:"onlyTwoOptions,omitempty"`
 }

--- a/tests/data/validation/typeMultiple/typeMultiple.json
+++ b/tests/data/validation/typeMultiple/typeMultiple.json
@@ -44,6 +44,12 @@
           "null"
         ]
       }
+    },
+    "onlyTwoOptions": {
+      "type": [
+        "number",
+        "boolean"
+      ]
     }
   }
 }


### PR DESCRIPTION
If you have a type with exactly two options, neither of which is null, then the null-checking logic incorrectly uses the last item in the list as the type instead of `interface{}`.

e.g. `"type": ["string", "boolean"]` becomes `*bool` instead of `interface{}` because the generation logic is assuming a two item type is only used when setting a type to null.