### PR TITLE
feat: add struct tags to `AdditionalProperties`

### DIFF
--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -603,7 +603,7 @@ func (g *schemaGenerator) generateStructType(
 				DefaultValue: defaultValue,
 				SchemaType:   &schemas.Type{},
 				Type:         fieldType,
-				Tags:         tags,
+				Tags:         strings.TrimSpace(tags),
 			},
 		)
 	}

--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -592,12 +592,18 @@ func (g *schemaGenerator) generateStructType(
 			}
 		}
 
+		tags := ""
+		for _, tag := range g.config.Tags {
+			tags += fmt.Sprintf(`%s:"-" `, tag)
+		}
+
 		structType.AddField(
 			codegen.StructField{
 				Name:         "AdditionalProperties",
 				DefaultValue: defaultValue,
 				SchemaType:   &schemas.Type{},
 				Type:         fieldType,
+				Tags:         tags,
 			},
 		)
 	}


### PR DESCRIPTION
As noted in #242, we are missing the `-` tag which allows picking up
the additional properties in i.e. a JSON object.

Closes #242.
