### PR TITLE
Use schema that doesn't come from a file

### DIFF
--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -132,10 +132,10 @@ func (g *Generator) DoFile(fileName string) error {
 		}
 	}
 
-	return g.addFile(fileName, schema)
+	return g.AddFile(fileName, schema)
 }
 
-func (g *Generator) addFile(fileName string, schema *schemas.Schema) error {
+func (g *Generator) AddFile(fileName string, schema *schemas.Schema) error {
 	o, err := g.findOutputFileForSchemaID(schema.ID)
 	if err != nil {
 		return err

--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -112,7 +112,7 @@ func (g *schemaGenerator) generateReferencedType(t *schemas.Type) (codegen.Type,
 			return nil, fmt.Errorf("could not resolve qualified file name for %s: %w", fileName, qerr)
 		}
 
-		if ferr := g.addFile(qualified, schema); ferr != nil {
+		if ferr := g.AddFile(qualified, schema); ferr != nil {
 			return nil, ferr
 		}
 


### PR DESCRIPTION
It is sometimes useful to place the json schema in a file which may also contain other config. For example:

```yaml
fields:
  not:

used:
  by:
  json_schema:

json_schema:
```

In the above example, we'd only need to give go-jsonschema the config which is under `json_schema`. The way I've been doing it so far is by making `addFile` a public function. Do you think this is ok? 