### PR TITLE
pkg/generator: support validation regex literals

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,7 +200,7 @@ golang-install-tools:
 .PHONY: tools-go tools-brew
 
 tools-go:
-	@scripts/tools-golang.sh
+	@scripts/golang-install-tools.sh
 
 tools-brew:
 	@scripts/tools-brew.sh

--- a/pkg/generator/validator.go
+++ b/pkg/generator/validator.go
@@ -244,9 +244,15 @@ func (v *stringValidator) generate(out *codegen.Emitter) {
 			out.Indent(1)
 		}
 
-		out.Printlnf(`if matched, _ := regexp.MatchString("%s", string(%s%s)); !matched {`, v.pattern, pointerPrefix, value)
+		out.Printlnf(
+			`if matched, _ := regexp.MatchString(`+"`%s`"+`, string(%s%s)); !matched {`,
+			v.pattern, pointerPrefix, value,
+		)
 		out.Indent(1)
-		out.Printlnf(`return fmt.Errorf("field %%s pattern match: must match %%s", "%s", "%s")`, v.pattern, v.fieldName)
+		out.Printlnf(
+			`return fmt.Errorf("field %%s pattern match: must match %%s", `+"`%s`"+`, "%s")`,
+			v.pattern, v.fieldName,
+		)
 		out.Indent(-1)
 		out.Printlnf("}")
 

--- a/tests/data/validation/pattern/pattern.go
+++ b/tests/data/validation/pattern/pattern.go
@@ -29,12 +29,12 @@ func (j *Pattern) UnmarshalJSON(b []byte) error {
 		return err
 	}
 	if plain.MyNullableString != nil {
-		if matched, _ := regexp.MatchString("^0x[0-9a-f]{10}$", string(*plain.MyNullableString)); !matched {
-			return fmt.Errorf("field %s pattern match: must match %s", "^0x[0-9a-f]{10}$", "MyNullableString")
+		if matched, _ := regexp.MatchString(`^0x[0-9a-f]{10}$`, string(*plain.MyNullableString)); !matched {
+			return fmt.Errorf("field %s pattern match: must match %s", `^0x[0-9a-f]{10}$`, "MyNullableString")
 		}
 	}
-	if matched, _ := regexp.MatchString("^0x[0-9a-f]{10}$", string(plain.MyString)); !matched {
-		return fmt.Errorf("field %s pattern match: must match %s", "^0x[0-9a-f]{10}$", "MyString")
+	if matched, _ := regexp.MatchString(`^0x[0-9a-f]{10}\.$`, string(plain.MyString)); !matched {
+		return fmt.Errorf("field %s pattern match: must match %s", `^0x[0-9a-f]{10}\.$`, "MyString")
 	}
 	*j = Pattern(plain)
 	return nil

--- a/tests/data/validation/pattern/pattern.json
+++ b/tests/data/validation/pattern/pattern.json
@@ -5,7 +5,7 @@
   "properties": {
     "myString": {
       "type": "string",
-      "pattern": "^0x[0-9a-f]{10}$"
+      "pattern": "^0x[0-9a-f]{10}\\.$"
     },
     "myNullableString": {
       "type": "string",

--- a/tests/generation_test.go
+++ b/tests/generation_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/atombender/go-jsonschema/pkg/generator"
 )
 
@@ -240,6 +242,10 @@ func testExampleFile(t *testing.T, cfg generator.Config, fileName string) {
 				if err = os.WriteFile(goldenFileName, goldenData, 0o655); err != nil {
 					t.Fatal(err)
 				}
+			}
+
+			if diff := cmp.Diff(string(goldenData), string(source)); diff != "" {
+				t.Errorf("Contents different (left is expected, right is actual):\n%s", diff)
 			}
 
 			if diff, ok := diffStrings(t, string(goldenData), string(source)); !ok {

--- a/tests/validation_test.go
+++ b/tests/validation_test.go
@@ -164,12 +164,12 @@ func TestPattern(t *testing.T) {
 	}{
 		{
 			desc: "no violations",
-			data: `{"myString": "0x12345abcde"}`,
+			data: `{"myString": "0x12345abcde."}`,
 		},
 		{
 			desc:    "myString does not match pattern",
 			data:    `{"myString": "0x123456"}`,
-			wantErr: errors.New("field ^0x[0-9a-f]{10}$ pattern match: must match MyString"),
+			wantErr: errors.New("field ^0x[0-9a-f]{10}\\.$ pattern match: must match MyString"),
 		},
 	}
 


### PR DESCRIPTION
Often, regular expressions used for validating strings will contain complex escape sequences. Once we read those in during schema ingest, we will have the escaped values, but we cannot paste those into a double-quote string in Go as we would need to re-escape the sequences. If we instead use a back-tick string, we can use the regular expressions verbatim.