### PR TITLE
fix: use default output when no schema output is defined

### DIFF
--- a/main.go
+++ b/main.go
@@ -87,6 +87,8 @@ var (
 				}
 				if s, ok := schemaOutputMap[id]; ok {
 					mapping.OutputName = s
+				} else {
+					mapping.OutputName = defaultOutput
 				}
 				if s, ok := schemaRootTypeMap[id]; ok {
 					mapping.RootType = s


### PR DESCRIPTION
In all examples, the output is defined. There was a missed use case where the out was not defined but another mapping is used.

Closes #403