### PR TITLE
Add support for time zone offsets in json format "time" fields

### DIFF
--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -30,21 +30,25 @@ func (t *SerializableTime) UnmarshalJSON(data []byte) error {
 
 	timeWithoutQuotes := stringifiedData[1 : len(stringifiedData)-1]
 
-	// RFC 3339 full-time layouts:
+	// RFC 3339 full-time layouts.
 	layouts := []string{
-		"15:04:05",       // Time without offset
-		"15:04:05Z07:00", // Time with offset. works with ..Z, ..+09:00 ...
+		"15:04:05",       // Time without offset.
+		"15:04:05Z07:00", // Time with offset. Works with ..Z, ..+09:00 ...
 	}
 
 	var parsedTime time.Time
+
 	var err error
+
 	for _, layout := range layouts {
 		parsedTime, err = time.Parse(layout, timeWithoutQuotes)
 		if err == nil {
 			t.Time = parsedTime
+
 			return nil
 		}
 	}
+
 	if err != nil {
 		return fmt.Errorf("unable to parse time from JSON: %w", err)
 	}

--- a/pkg/types/time.go
+++ b/pkg/types/time.go
@@ -30,12 +30,24 @@ func (t *SerializableTime) UnmarshalJSON(data []byte) error {
 
 	timeWithoutQuotes := stringifiedData[1 : len(stringifiedData)-1]
 
-	parsedTime, err := time.Parse(time.TimeOnly, timeWithoutQuotes)
+	// RFC 3339 full-time layouts:
+	layouts := []string{
+		"15:04:05",       // Time without offset
+		"15:04:05Z07:00", // Time with offset. works with ..Z, ..+09:00 ...
+	}
+
+	var parsedTime time.Time
+	var err error
+	for _, layout := range layouts {
+		parsedTime, err = time.Parse(layout, timeWithoutQuotes)
+		if err == nil {
+			t.Time = parsedTime
+			return nil
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("unable to parse time from JSON: %w", err)
 	}
-
-	t.Time = parsedTime
 
 	return nil
 }


### PR DESCRIPTION
Small pull request to also support RFC 3339 time formats in SerializableTime:
12:34:56Z07:00
12:34:56+09:00
