### PR TITLE
Let tests overwrite the expected Go file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ Note the flag format:
                  schema $id                  full import URL
 ```
 
+### Regenerating tests' golden files
+
+It sometimes happen that new features or bug fixes to the library require regenerating the tests' golden files, here's how to do it:
+
+```
+export OVERWRITE_EXPECTED_GO_FILE="true"
+make test
+```
+
 ### Special types
 
 In a few cases, special types are used to help with serializing/deserializing

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 )
 
 const (
-	perm755 = 0o755
 	perm644 = 0o644
+	perm755 = 0o755
 )
 
 var (

--- a/tests/generation_test.go
+++ b/tests/generation_test.go
@@ -268,9 +268,10 @@ func testExampleFile(t *testing.T, cfg generator.Config, fileName string) {
 				// due to a code change you made and you just want to accept the new output.
 				// Simply run "OVERWRITE_EXPECTED_GO_FILE=true make test".
 				if os.Getenv("OVERWRITE_EXPECTED_GO_FILE") == "true" {
-					t.Logf("Writing expected output to %s\n", string(goldenFileName))
+					t.Logf("Writing expected output to %s\n", goldenFileName)
+
 					if err = os.WriteFile(goldenFileName, source, 0o655); err != nil {
-						t.Logf("Failed to write to %s\n", string(goldenFileName))
+						t.Logf("Failed to write to %s\n", goldenFileName)
 					}
 				}
 			}

--- a/tests/generation_test.go
+++ b/tests/generation_test.go
@@ -263,6 +263,16 @@ func testExampleFile(t *testing.T, cfg generator.Config, fileName string) {
 
 			if diff := cmp.Diff(string(goldenData), string(source)); diff != "" {
 				t.Errorf("Contents different (left is expected, right is actual):\n%s", diff)
+
+				// Overwriting the expected file is useful if there are lots of differences
+				// due to a code change you made and you just want to accept the new output.
+				// Simply run "OVERWRITE_EXPECTED_GO_FILE=true make test".
+				if os.Getenv("OVERWRITE_EXPECTED_GO_FILE") == "true" {
+					t.Logf("Writing expected output to %s\n", string(goldenFileName))
+					if err = os.WriteFile(goldenFileName, source, 0o655); err != nil {
+						t.Logf("Failed to write to %s\n", string(goldenFileName))
+					}
+				}
 			}
 
 			if diff, ok := diffStrings(t, string(goldenData), string(source)); !ok {


### PR DESCRIPTION
This is useful if there are lots of differences due to a code change you made and you just want to accept the new output.