### PR TITLE
fix: Make generateEnumType work for nillable vals

### DIFF
--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -1126,10 +1126,23 @@ func (g *schemaGenerator) generateEnumType(
 
 	var enumType codegen.Type
 
-	if len(t.Type) == 1 {
+	schemaType := make([]string, len(t.Type))
+	copy(schemaType, t.Type)
+
+	nullIdx := slices.Index(schemaType, schemas.TypeNameNull)
+
+	if len(schemaType) == 2 && nullIdx != -1 {
+		if nullIdx == 0 {
+			schemaType = schemaType[1:]
+		} else {
+			schemaType = schemaType[:1]
+		}
+	}
+
+	if len(schemaType) == 1 {
 		var err error
 		if enumType, err = codegen.PrimitiveTypeFromJSONSchemaType(
-			t.Type[0],
+			schemaType[0],
 			t.Format,
 			false,
 			g.config.MinSizedInts,
@@ -1138,11 +1151,11 @@ func (g *schemaGenerator) generateEnumType(
 			&t.ExclusiveMinimum,
 			&t.ExclusiveMaximum,
 		); err != nil {
-			return nil, fmt.Errorf("invalid type %q: %w", t.Type[0], err)
+			return nil, fmt.Errorf("invalid type %q: %w", schemaType[0], err)
 		}
 
 		// Enforce integer type for enum values.
-		if t.Type[0] == "integer" {
+		if schemaType[0] == "integer" {
 			for i, v := range t.Enum {
 				switch v := v.(type) {
 				case float64:
@@ -1154,9 +1167,9 @@ func (g *schemaGenerator) generateEnumType(
 			}
 		}
 
-		wrapInStruct = t.Type[0] == schemas.TypeNameNull // Null uses interface{}, which cannot have methods.
+		wrapInStruct = schemaType[0] == schemas.TypeNameNull // Null uses interface{}, which cannot have methods.
 	} else {
-		if len(t.Type) > 1 {
+		if len(schemaType) > 1 {
 			// TODO: Support multiple types.
 			g.warner("Enum defined with multiple types; ignoring it and using enum values instead")
 		}
@@ -1167,21 +1180,21 @@ func (g *schemaGenerator) generateEnumType(
 			var valueType string
 
 			if v == nil {
-				valueType = interfaceTypeName
-			} else {
-				switch v.(type) {
-				case string:
-					valueType = "string"
+				continue
+			}
 
-				case float64:
-					valueType = float64Type
+			switch v.(type) {
+			case string:
+				valueType = "string"
 
-				case bool:
-					valueType = "bool"
+			case float64:
+				valueType = float64Type
 
-				default:
-					return nil, fmt.Errorf("%w %v", errEnumNonPrimitiveVal, v)
-				}
+			case bool:
+				valueType = "bool"
+
+			default:
+				return nil, fmt.Errorf("%w %v", errEnumNonPrimitiveVal, v)
 			}
 
 			if primitiveType == "" {


### PR DESCRIPTION
Currently, if there is an enum type whose schema types are `["simple_type", "null"]`, the generator will wrap it in a struct. When it appears in a JSON body, it fails unmarshalling when only models are generated. However, when Unmarshallers are generated and there is a default value, the generated code has an error in it. This fix checks to see if the type has 2 elements and if one of them is null, it strips it out and pretends it only had one.

I verified this works testing sample schemae from Github Webhook Events successfully. Once I have the code checked in, I will share here for an example.