### PR TITLE
fix: handle arrays without item type by returning []interface{}

### DIFF
--- a/pkg/generator/generate.go
+++ b/pkg/generator/generate.go
@@ -21,7 +21,6 @@ const (
 
 var (
 	errSchemaHasNoRoot                = errors.New("schema has no root")
-	errArrayPropertyItems             = errors.New("array property must have 'items' set to a type")
 	errEnumArrCannotBeEmpty           = errors.New("enum array cannot be empty")
 	errEnumNonPrimitiveVal            = errors.New("enum has non-primitive value")
 	errMapURIToPackageName            = errors.New("unable to map schema URI to Go package name")

--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -570,7 +570,7 @@ func (g *schemaGenerator) generateType(t *schemas.Type, scope nameScope) (codege
 	switch typeName {
 	case schemas.TypeNameArray:
 		if t.Items == nil {
-			return nil, errArrayPropertyItems
+			return codegen.ArrayType{Type: codegen.EmptyInterfaceType{}}, nil
 		}
 
 		elemType, err := g.generateType(t.Items, g.singularScope(scope))

--- a/tests/data/core/array/array.go
+++ b/tests/data/core/array/array.go
@@ -22,6 +22,10 @@ type Array struct {
 	// MyNullArray corresponds to the JSON schema field "myNullArray".
 	MyNullArray []interface{} `json:"myNullArray,omitempty" yaml:"myNullArray,omitempty" mapstructure:"myNullArray,omitempty"`
 
+	// MyNullableUntypedArray corresponds to the JSON schema field
+	// "myNullableUntypedArray".
+	MyNullableUntypedArray *ArrayMyNullableUntypedArray `json:"myNullableUntypedArray,omitempty" yaml:"myNullableUntypedArray,omitempty" mapstructure:"myNullableUntypedArray,omitempty"`
+
 	// MyNumberArray corresponds to the JSON schema field "myNumberArray".
 	MyNumberArray []float64 `json:"myNumberArray,omitempty" yaml:"myNumberArray,omitempty" mapstructure:"myNumberArray,omitempty"`
 
@@ -31,6 +35,8 @@ type Array struct {
 	// MyStringArray corresponds to the JSON schema field "myStringArray".
 	MyStringArray []string `json:"myStringArray,omitempty" yaml:"myStringArray,omitempty" mapstructure:"myStringArray,omitempty"`
 }
+
+type ArrayMyNullableUntypedArray []interface{}
 
 type ArrayMyObjectArrayElem map[string]interface{}
 

--- a/tests/data/core/array/array.json
+++ b/tests/data/core/array/array.json
@@ -50,6 +50,9 @@
           "type": "null"
         }
       }
+    },
+    "myNullableUntypedArray": {
+      "type": ["array", "null"]
     }
   }
 }


### PR DESCRIPTION
When an array type has no 'items' property set, return []interface{}
instead of failing with "array property must have 'items' set to a type".

This matches the existing behavior in generateTypeInline and allows
schemas with nullable untyped arrays (e.g., "type": ["array", "null"])
to be processed successfully.
