### PR TITLE
use UTF-8 rune count instead of raw byte count for string length validation

### DIFF
--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -525,14 +525,16 @@ func (g *schemaGenerator) generateUnmarshaler(decl *codegen.TypeDecl, validators
 			g.output.file.Package.AddImport("errors", "")
 		}
 
+		if sv, ok := v.(*stringValidator); ok && (sv.minLength != 0 || sv.maxLength != 0) {
+			g.output.file.Package.AddImport("unicode/utf8", "")
+		}
+
 		for _, pkg := range v.desc().imports {
 			g.output.file.Package.AddImport(pkg.qualifiedName, "")
 		}
 
 		if v.desc().hasError {
 			g.output.file.Package.AddImport("fmt", "")
-
-			break
 		}
 	}
 

--- a/pkg/generator/validator.go
+++ b/pkg/generator/validator.go
@@ -408,7 +408,7 @@ func (v *stringValidator) generate(out *codegen.Emitter, format string) error {
 	}
 
 	if v.minLength != 0 {
-		out.Printlnf(`if %slen(%s%s) < %d {`, checkPointer, pointerPrefix, value, v.minLength)
+		out.Printlnf(`if %sutf8.RuneCountInString(string(%s%s)) < %d {`, checkPointer, pointerPrefix, value, v.minLength)
 		out.Indent(1)
 		out.Printlnf(`return fmt.Errorf("field %%s length: must be >= %%d", "%s", %d)`, fieldName, v.minLength)
 		out.Indent(-1)
@@ -416,7 +416,7 @@ func (v *stringValidator) generate(out *codegen.Emitter, format string) error {
 	}
 
 	if v.maxLength != 0 {
-		out.Printlnf(`if %slen(%s%s) > %d {`, checkPointer, pointerPrefix, value, v.maxLength)
+		out.Printlnf(`if %sutf8.RuneCountInString(string(%s%s)) > %d {`, checkPointer, pointerPrefix, value, v.maxLength)
 		out.Indent(1)
 		out.Printlnf(`return fmt.Errorf("field %%s length: must be <= %%d", "%s", %d)`, fieldName, v.maxLength)
 		out.Indent(-1)

--- a/tests/data/core/additionalProperties/autoinstallSchema.go
+++ b/tests/data/core/additionalProperties/autoinstallSchema.go
@@ -9,6 +9,7 @@ import yaml "gopkg.in/yaml.v3"
 import "reflect"
 import "regexp"
 import "strings"
+import "unicode/utf8"
 
 type AutoinstallSchema struct {
 	// ActiveDirectory corresponds to the JSON schema field "active-directory".
@@ -731,10 +732,10 @@ func (j *AutoinstallSchemaUbuntuAdvantage) UnmarshalJSON(value []byte) error {
 			return fmt.Errorf("field %s pattern match: must match %s", "Token", `^C[1-9A-HJ-NP-Za-km-z]+$`)
 		}
 	}
-	if plain.Token != nil && len(*plain.Token) < 24 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) < 24 {
 		return fmt.Errorf("field %s length: must be >= %d", "token", 24)
 	}
-	if plain.Token != nil && len(*plain.Token) > 30 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) > 30 {
 		return fmt.Errorf("field %s length: must be <= %d", "token", 30)
 	}
 	*j = AutoinstallSchemaUbuntuAdvantage(plain)
@@ -753,10 +754,10 @@ func (j *AutoinstallSchemaUbuntuAdvantage) UnmarshalYAML(value *yaml.Node) error
 			return fmt.Errorf("field %s pattern match: must match %s", "Token", `^C[1-9A-HJ-NP-Za-km-z]+$`)
 		}
 	}
-	if plain.Token != nil && len(*plain.Token) < 24 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) < 24 {
 		return fmt.Errorf("field %s length: must be >= %d", "token", 24)
 	}
-	if plain.Token != nil && len(*plain.Token) > 30 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) > 30 {
 		return fmt.Errorf("field %s length: must be <= %d", "token", 30)
 	}
 	*j = AutoinstallSchemaUbuntuAdvantage(plain)
@@ -781,10 +782,10 @@ func (j *AutoinstallSchemaUbuntuPro) UnmarshalJSON(value []byte) error {
 			return fmt.Errorf("field %s pattern match: must match %s", "Token", `^C[1-9A-HJ-NP-Za-km-z]+$`)
 		}
 	}
-	if plain.Token != nil && len(*plain.Token) < 24 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) < 24 {
 		return fmt.Errorf("field %s length: must be >= %d", "token", 24)
 	}
-	if plain.Token != nil && len(*plain.Token) > 30 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) > 30 {
 		return fmt.Errorf("field %s length: must be <= %d", "token", 30)
 	}
 	*j = AutoinstallSchemaUbuntuPro(plain)
@@ -803,10 +804,10 @@ func (j *AutoinstallSchemaUbuntuPro) UnmarshalYAML(value *yaml.Node) error {
 			return fmt.Errorf("field %s pattern match: must match %s", "Token", `^C[1-9A-HJ-NP-Za-km-z]+$`)
 		}
 	}
-	if plain.Token != nil && len(*plain.Token) < 24 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) < 24 {
 		return fmt.Errorf("field %s length: must be >= %d", "token", 24)
 	}
-	if plain.Token != nil && len(*plain.Token) > 30 {
+	if plain.Token != nil && utf8.RuneCountInString(string(*plain.Token)) > 30 {
 		return fmt.Errorf("field %s length: must be <= %d", "token", 30)
 	}
 	*j = AutoinstallSchemaUbuntuPro(plain)

--- a/tests/data/core/allOf/allOf.4.go
+++ b/tests/data/core/allOf/allOf.4.go
@@ -6,6 +6,7 @@ import "encoding/json"
 import "fmt"
 import yaml "gopkg.in/yaml.v3"
 import "reflect"
+import "unicode/utf8"
 
 type AllOf4 []AllOf4Elem
 
@@ -50,7 +51,7 @@ func (j *AllOf4Elem) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.LinkKind) < 1 {
+	if utf8.RuneCountInString(string(plain.LinkKind)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "linkKind", 1)
 	}
 	*j = AllOf4Elem(plain)
@@ -80,7 +81,7 @@ func (j *AllOf4Elem) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.LinkKind) < 1 {
+	if utf8.RuneCountInString(string(plain.LinkKind)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "linkKind", 1)
 	}
 	*j = AllOf4Elem(plain)
@@ -120,7 +121,7 @@ func (j *EmbeddedlinkendFrom) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkendFrom(plain)
@@ -141,7 +142,7 @@ func (j *EmbeddedlinkendFrom) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkendFrom(plain)
@@ -267,7 +268,7 @@ func (j *EmbeddedlinkpathFrom) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkpathFrom(plain)
@@ -288,7 +289,7 @@ func (j *EmbeddedlinkpathFrom) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkpathFrom(plain)
@@ -463,7 +464,7 @@ func (j *EmbeddedlinkrelationTarget) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if plain.ContextId != nil && len(*plain.ContextId) < 1 {
+	if plain.ContextId != nil && utf8.RuneCountInString(string(*plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkrelationTarget(plain)
@@ -477,7 +478,7 @@ func (j *EmbeddedlinkrelationTarget) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if plain.ContextId != nil && len(*plain.ContextId) < 1 {
+	if plain.ContextId != nil && utf8.RuneCountInString(string(*plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkrelationTarget(plain)
@@ -504,7 +505,7 @@ func (j *Embeddedlinkrelation) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.LinkKind) < 1 {
+	if utf8.RuneCountInString(string(plain.LinkKind)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "linkKind", 1)
 	}
 	*j = Embeddedlinkrelation(plain)
@@ -531,7 +532,7 @@ func (j *Embeddedlinkrelation) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.LinkKind) < 1 {
+	if utf8.RuneCountInString(string(plain.LinkKind)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "linkKind", 1)
 	}
 	*j = Embeddedlinkrelation(plain)

--- a/tests/data/core/anyOf/anyOf.4.go
+++ b/tests/data/core/anyOf/anyOf.4.go
@@ -7,6 +7,7 @@ import "errors"
 import "fmt"
 import yaml "gopkg.in/yaml.v3"
 import "reflect"
+import "unicode/utf8"
 
 type AnyOf4 []AnyOf4Elem
 
@@ -123,7 +124,7 @@ func (j *EmbeddedlinkendFrom) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkendFrom(plain)
@@ -144,7 +145,7 @@ func (j *EmbeddedlinkendFrom) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkendFrom(plain)
@@ -270,7 +271,7 @@ func (j *EmbeddedlinkpathFrom) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkpathFrom(plain)
@@ -291,7 +292,7 @@ func (j *EmbeddedlinkpathFrom) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.ContextId) < 1 {
+	if utf8.RuneCountInString(string(plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkpathFrom(plain)
@@ -466,7 +467,7 @@ func (j *EmbeddedlinkrelationTarget) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if plain.ContextId != nil && len(*plain.ContextId) < 1 {
+	if plain.ContextId != nil && utf8.RuneCountInString(string(*plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkrelationTarget(plain)
@@ -480,7 +481,7 @@ func (j *EmbeddedlinkrelationTarget) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if plain.ContextId != nil && len(*plain.ContextId) < 1 {
+	if plain.ContextId != nil && utf8.RuneCountInString(string(*plain.ContextId)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "contextId", 1)
 	}
 	*j = EmbeddedlinkrelationTarget(plain)
@@ -507,7 +508,7 @@ func (j *Embeddedlinkrelation) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.LinkKind) < 1 {
+	if utf8.RuneCountInString(string(plain.LinkKind)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "linkKind", 1)
 	}
 	*j = Embeddedlinkrelation(plain)
@@ -540,7 +541,7 @@ func (j *Embeddedlinkrelation) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.LinkKind) < 1 {
+	if utf8.RuneCountInString(string(plain.LinkKind)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "linkKind", 1)
 	}
 	*j = Embeddedlinkrelation(plain)

--- a/tests/data/deeplyNested/standalone/RolloutSpecification.go
+++ b/tests/data/deeplyNested/standalone/RolloutSpecification.go
@@ -6,6 +6,7 @@ import "encoding/json"
 import "fmt"
 import yaml "gopkg.in/yaml.v3"
 import "regexp"
+import "unicode/utf8"
 
 // The details of applications to be deployed.
 type Applications struct {
@@ -376,10 +377,10 @@ func (j *OrchestratedStep) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.Name) < 1 {
+	if utf8.RuneCountInString(string(plain.Name)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "name", 1)
 	}
-	if plain.TargetName != nil && len(*plain.TargetName) < 1 {
+	if plain.TargetName != nil && utf8.RuneCountInString(string(*plain.TargetName)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "targetName", 1)
 	}
 	if matched, _ := regexp.MatchString(`(?i)(^ServiceResourceGroup$|^ServiceResource$|^Application$)`, string(plain.TargetType)); !matched {
@@ -406,10 +407,10 @@ func (j *OrchestratedStep) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.Name) < 1 {
+	if utf8.RuneCountInString(string(plain.Name)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "name", 1)
 	}
-	if plain.TargetName != nil && len(*plain.TargetName) < 1 {
+	if plain.TargetName != nil && utf8.RuneCountInString(string(*plain.TargetName)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "targetName", 1)
 	}
 	if matched, _ := regexp.MatchString(`(?i)(^ServiceResourceGroup$|^ServiceResource$|^Application$)`, string(plain.TargetType)); !matched {
@@ -592,7 +593,7 @@ func (j *RolloutMetadata) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain.Name) < 1 {
+	if utf8.RuneCountInString(string(plain.Name)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "name", 1)
 	}
 	if matched, _ := regexp.MatchString(`(?i)(^Major$|^Minor$|^Hotfix$)`, string(plain.RolloutType)); !matched {
@@ -625,7 +626,7 @@ func (j *RolloutMetadata) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain.Name) < 1 {
+	if utf8.RuneCountInString(string(plain.Name)) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "name", 1)
 	}
 	if matched, _ := regexp.MatchString(`(?i)(^Major$|^Minor$|^Hotfix$)`, string(plain.RolloutType)); !matched {

--- a/tests/data/validation/maxLength/maxLength.go
+++ b/tests/data/validation/maxLength/maxLength.go
@@ -5,6 +5,7 @@ package test
 import "encoding/json"
 import "fmt"
 import yaml "gopkg.in/yaml.v3"
+import "unicode/utf8"
 
 type MaxLength struct {
 	// MyNullableString corresponds to the JSON schema field "myNullableString".
@@ -28,10 +29,10 @@ func (j *MaxLength) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if plain.MyNullableString != nil && len(*plain.MyNullableString) > 10 {
+	if plain.MyNullableString != nil && utf8.RuneCountInString(string(*plain.MyNullableString)) > 10 {
 		return fmt.Errorf("field %s length: must be <= %d", "myNullableString", 10)
 	}
-	if len(plain.MyString) > 5 {
+	if utf8.RuneCountInString(string(plain.MyString)) > 5 {
 		return fmt.Errorf("field %s length: must be <= %d", "myString", 5)
 	}
 	*j = MaxLength(plain)
@@ -52,10 +53,10 @@ func (j *MaxLength) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if plain.MyNullableString != nil && len(*plain.MyNullableString) > 10 {
+	if plain.MyNullableString != nil && utf8.RuneCountInString(string(*plain.MyNullableString)) > 10 {
 		return fmt.Errorf("field %s length: must be <= %d", "myNullableString", 10)
 	}
-	if len(plain.MyString) > 5 {
+	if utf8.RuneCountInString(string(plain.MyString)) > 5 {
 		return fmt.Errorf("field %s length: must be <= %d", "myString", 5)
 	}
 	*j = MaxLength(plain)

--- a/tests/data/validation/minLength/minLength.go
+++ b/tests/data/validation/minLength/minLength.go
@@ -5,6 +5,7 @@ package test
 import "encoding/json"
 import "fmt"
 import yaml "gopkg.in/yaml.v3"
+import "unicode/utf8"
 
 type MinLength struct {
 	// MyNullableString corresponds to the JSON schema field "myNullableString".
@@ -28,10 +29,10 @@ func (j *MinLength) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if plain.MyNullableString != nil && len(*plain.MyNullableString) < 10 {
+	if plain.MyNullableString != nil && utf8.RuneCountInString(string(*plain.MyNullableString)) < 10 {
 		return fmt.Errorf("field %s length: must be >= %d", "myNullableString", 10)
 	}
-	if len(plain.MyString) < 5 {
+	if utf8.RuneCountInString(string(plain.MyString)) < 5 {
 		return fmt.Errorf("field %s length: must be >= %d", "myString", 5)
 	}
 	*j = MinLength(plain)
@@ -52,10 +53,10 @@ func (j *MinLength) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if plain.MyNullableString != nil && len(*plain.MyNullableString) < 10 {
+	if plain.MyNullableString != nil && utf8.RuneCountInString(string(*plain.MyNullableString)) < 10 {
 		return fmt.Errorf("field %s length: must be >= %d", "myNullableString", 10)
 	}
-	if len(plain.MyString) < 5 {
+	if utf8.RuneCountInString(string(plain.MyString)) < 5 {
 		return fmt.Errorf("field %s length: must be >= %d", "myString", 5)
 	}
 	*j = MinLength(plain)

--- a/tests/data/validation/primitive_defs/primitive_defs.go
+++ b/tests/data/validation/primitive_defs/primitive_defs.go
@@ -5,6 +5,7 @@ package test
 import "encoding/json"
 import "fmt"
 import yaml "gopkg.in/yaml.v3"
+import "unicode/utf8"
 
 type MinStr string
 
@@ -15,7 +16,7 @@ func (j *MinStr) UnmarshalJSON(value []byte) error {
 	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
-	if len(plain) < 5 {
+	if utf8.RuneCountInString(string(plain)) < 5 {
 		return fmt.Errorf("field %s length: must be >= %d", "", 5)
 	}
 	*j = MinStr(plain)
@@ -29,7 +30,7 @@ func (j *MinStr) UnmarshalYAML(value *yaml.Node) error {
 	if err := value.Decode(&plain); err != nil {
 		return err
 	}
-	if len(plain) < 5 {
+	if utf8.RuneCountInString(string(plain)) < 5 {
 		return fmt.Errorf("field %s length: must be >= %d", "", 5)
 	}
 	*j = MinStr(plain)


### PR DESCRIPTION
addresses https://github.com/omissis/go-jsonschema/issues/183

string validation `minLength` and `maxLength` should not rely on `len()` which returns the number of bytes in an object, instead they should leverage `utf8.RuneCountInString()` which returns the number of unicode code points (characters) in a string. 

for example, the string `á` contains 2 bytes but only 1 character