### PR TITLE
ci: bootstrap buildx "container" builder in development workflow

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -35,6 +35,8 @@ jobs:
         run: ./scripts/test.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6
+      - name: Create dedicated docker buildx builder instance
+        run: docker buildx create --driver=docker-container --name container --use
       - name: Build binaries
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:


### PR DESCRIPTION
## Summary

The development workflow runs goreleaser in snapshot mode on every PR and main push, which (since #555 / `9050015`) tries to build docker images via the named buildx builder `container`.

`prerelease.yaml` and `release.yaml` got the corresponding `docker buildx create --driver=docker-container --name container` step in that commit, but `development.yaml` was missed — so the snapshot build now fails on every PR with:

```
ERROR: no builder "container" found
```

This adds the same one-line step to `development.yaml`. Pure parity with the other two workflows.

## Test plan

- [x] One-line addition mirrors the existing step in `prerelease.yaml:30-31` and `release.yaml:36-37`
- [x] CI on this PR confirms the snapshot build now succeeds (was failing on every recent PR — easy to verify by comparing to any other open PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized build pipeline configuration

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omissis/go-jsonschema/pull/559)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Stack position

This PR is part of a stacked series. Suggested merge order (bottom-up):

1. **omissis/go-jsonschema#559 — `ci: bootstrap buildx "container" builder in development workflow` ← this PR**
2. omissis/go-jsonschema#563 — `ci: configure CodeRabbit to auto-review stacked-PR base branches`
3. omissis/go-jsonschema#561 — `ci: activate the docker-container buildx builder with --use`
4. omissis/go-jsonschema#546 — `refactor: extract shared Unmarshal{JSON,YAML} body into helper`
5. omissis/go-jsonschema#547 — `feat: opt-in runtime validation of JSON Schema format keywords`
6. omissis/go-jsonschema#548 — `feat: opt-in enforcement of additionalProperties: false`
7. omissis/go-jsonschema#549 — `feat: emit typed wrapper for primitive oneOf schemas`
8. omissis/go-jsonschema#566 — `feat: discriminated oneOf via natural-discriminator detection`
9. omissis/go-jsonschema#567 — `feat: try-each oneOf fallback for object variants without natural discriminator`
10. omissis/go-jsonschema#568 — `test: add recursive allOf+$ref regression coverage`
11. omissis/go-jsonschema#569 — `feat: support root-level composition (oneOf/anyOf/allOf/$ref/enum/const) schemas`
12. omissis/go-jsonschema#571 — `feat: warn when interface{} fallback silently drops user-meaningful keywords`
13. omissis/go-jsonschema#572 — `feat: compile allOf+if/then[/else] tagged-union pattern as runtime validator`
14. omissis/go-jsonschema#573 — `feat: cross-tree $ref support via --known-schema and --schema-package alias override`
15. omissis/go-jsonschema#574 — `feat: detect multi-type-union form, route through primitive wrapper`

The diff currently includes commits from earlier PRs in the stack because they aren't merged yet; once each lower PR lands, this PR's diff will automatically shrink to just its own contribution. No action needed on the contributor side between merges — GitHub recomputes the diff vs `main` after each merge.
