### PR TITLE
ci: activate the docker-container buildx builder with --use

### DIFF
--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup workspace
         run: cp go.work.dist go.work
       - name: Create dedicated docker buildx builder instance
-        run: docker buildx create --driver=docker-container --name container
+        run: docker buildx create --driver=docker-container --name container --use
       - name: Run GoReleaser for release
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
       - name: Create dedicated docker buildx builder instance
-        run: docker buildx create --driver=docker-container --name container
+        run: docker buildx create --driver=docker-container --name container --use
       - name: Run GoReleaser for release
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7
         with:


### PR DESCRIPTION
## Summary

`release.yaml` and `prerelease.yaml` create a dedicated buildx builder named `container` but never activate it — `docker buildx create --driver=docker-container --name container` is missing the `--use` flag, and no follow-up `docker buildx use container` step exists.

When goreleaser then runs `docker buildx build --builder=container ...`, the named-builder lookup happens against the active builder context (not the global list), so the build fails with:

```
ERROR: no builder "container" found
```

even though the preceding step appears to have created one.

This PR adds `--use` at create time to both workflows, atomically selecting the new builder and matching the documented buildx pattern.

## Why this matters

This is the same root cause as the `qa` failure that was hitting every PR built with the `development` workflow. #559 fixed the missing buildx step in `development.yaml`, but `release.yaml` and `prerelease.yaml` have always had the latent omission since 9050015 introduced the dedicated builder. The bug is invisible until a release tag is pushed, at which point the release workflow would fail the same way.

## Scope

- `release.yaml`: add `--use`
- `prerelease.yaml`: add `--use`
- `development.yaml` is touched by #559 with the same omission; that PR can absorb `--use` independently or after this lands.

## Test plan

- [x] `git diff` shows two single-line additions (one per file)
- [ ] Verify next prerelease tag pushes succeed (cannot run from a PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI/CD workflows now create and select a dedicated Docker Buildx builder before build steps, improving build consistency and reliability across release, prerelease, and development pipelines.
  * Added CodeRabbit review automation configuration to enable scoped auto-reviews for feature, fix, and docs branches.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omissis/go-jsonschema/pull/561)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Stack position

This PR is part of a stacked series. Suggested merge order (bottom-up):

1. omissis/go-jsonschema#559 — `ci: bootstrap buildx "container" builder in development workflow`
2. omissis/go-jsonschema#563 — `ci: configure CodeRabbit to auto-review stacked-PR base branches`
3. **omissis/go-jsonschema#561 — `ci: activate the docker-container buildx builder with --use` ← this PR**
4. omissis/go-jsonschema#546 — `refactor: extract shared Unmarshal{JSON,YAML} body into helper`
5. omissis/go-jsonschema#547 — `feat: opt-in runtime validation of JSON Schema format keywords`
6. omissis/go-jsonschema#548 — `feat: opt-in enforcement of additionalProperties: false`
7. omissis/go-jsonschema#549 — `feat: emit typed wrapper for primitive oneOf schemas`
8. omissis/go-jsonschema#566 — `feat: discriminated oneOf via natural-discriminator detection`
9. omissis/go-jsonschema#567 — `feat: try-each oneOf fallback for object variants without natural discriminator`
10. omissis/go-jsonschema#568 — `test: add recursive allOf+$ref regression coverage`
11. omissis/go-jsonschema#569 — `feat: support root-level composition (oneOf/anyOf/allOf/$ref/enum/const) schemas`
12. omissis/go-jsonschema#571 — `feat: warn when interface{} fallback silently drops user-meaningful keywords`
13. omissis/go-jsonschema#572 — `feat: compile allOf+if/then[/else] tagged-union pattern as runtime validator`
14. omissis/go-jsonschema#573 — `feat: cross-tree $ref support via --known-schema and --schema-package alias override`
15. omissis/go-jsonschema#574 — `feat: detect multi-type-union form, route through primitive wrapper`

The diff currently includes commits from earlier PRs in the stack because they aren't merged yet; once each lower PR lands, this PR's diff will automatically shrink to just its own contribution. No action needed on the contributor side between merges — GitHub recomputes the diff vs `main` after each merge.
