### PR TITLE
ci: configure CodeRabbit to auto-review stacked-PR base branches

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,16 @@
+# CodeRabbit configuration for plheide/go-jsonschema fork.
+# Only non-default settings are listed here; everything else uses CR defaults.
+
+reviews:
+  auto_review:
+    # Auto-review PRs that target non-default base branches too — needed
+    # for stacked PRs where intermediate branches target each other
+    # (e.g., feat/p3 → feat/p2). Without this, CR posts:
+    #   "Review skipped — auto reviews are disabled on base/target
+    #    branches other than the default branch."
+    # Scoped to our actual branch-name conventions; if a new prefix is
+    # added (chore/, refactor/, etc.) it will need to be appended here.
+    base_branches:
+      - "^feat/.*"
+      - "^fix/.*"
+      - "^docs/.*"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -9,7 +9,7 @@ reviews:
     #   "Review skipped — auto reviews are disabled on base/target
     #    branches other than the default branch."
     # Scoped to our actual branch-name conventions; if a new prefix is
-    # added (chore/, refactor/, etc.) it will need to be appended here.
+    # added (refactor/, etc.) it will need to be appended here.
     base_branches:
       - "^feat/.*"
       - "^fix/.*"

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,4 +1,4 @@
-# CodeRabbit configuration for plheide/go-jsonschema fork.
+# CodeRabbit configuration for omissis/go-jsonschema.
 # Only non-default settings are listed here; everything else uses CR defaults.
 
 reviews:
@@ -14,3 +14,4 @@ reviews:
       - "^feat/.*"
       - "^fix/.*"
       - "^docs/.*"
+      - "^chore/.*"


### PR DESCRIPTION
## Summary

Adds `.coderabbit.yaml` to opt CodeRabbit into reviewing pull requests whose base branch is a feature branch (not just `main`). Without this, CodeRabbit skips review on PRs that target a non-default base — which is the exact pattern stacked PRs use, leaving each layer unreviewed unless the contributor manually triggers `@coderabbitai review`.

The 16-line config sets `reviews.auto_review.base_branches` to a permissive list so any branch can serve as a stack base.

## Why now

A stacked-PR series in this repo (omissis/go-jsonschema#546–#549, #559, #561) and on the upstream fork side targets parent branches rather than `main`. CodeRabbit silently skipped all but the bottom-most PRs until the contributor noticed and re-targeted to `main` to force reviews — losing the reviewability benefit of stacking.

This config restores the per-layer review behaviour without giving up the stacked-PR shape.

## Test plan

- [x] `git diff` shows only `.coderabbit.yaml` (16 lines added)
- [ ] After merge: any subsequent PR targeting a non-`main` base receives a CodeRabbit review automatically

## Stack position

This PR is part of a stacked series. Suggested merge order (bottom-up):

1. omissis/go-jsonschema#559 — `ci: bootstrap buildx "container" builder in development workflow`
2. **omissis/go-jsonschema#563 — `ci: configure CodeRabbit to auto-review stacked-PR base branches` ← this PR**
3. omissis/go-jsonschema#561 — `ci: activate the docker-container buildx builder with --use`
4. omissis/go-jsonschema#546 — `refactor: extract shared Unmarshal{JSON,YAML} body into helper`
5. omissis/go-jsonschema#547 — `feat: opt-in runtime validation of JSON Schema format keywords`
6. omissis/go-jsonschema#548 — `feat: opt-in enforcement of additionalProperties: false`
7. omissis/go-jsonschema#549 — `feat: emit typed wrapper for primitive oneOf schemas`
8. omissis/go-jsonschema#566 — `feat: discriminated oneOf via natural-discriminator detection`
9. omissis/go-jsonschema#567 — `feat: try-each oneOf fallback for object variants without natural discriminator`
10. omissis/go-jsonschema#568 — `test: add recursive allOf+$ref regression coverage`
11. omissis/go-jsonschema#569 — `feat: support root-level composition (oneOf/anyOf/allOf/$ref/enum/const) schemas`
12. omissis/go-jsonschema#571 — `feat: warn when interface{} fallback silently drops user-meaningful keywords`
13. omissis/go-jsonschema#572 — `feat: compile allOf+if/then[/else] tagged-union pattern as runtime validator`
14. omissis/go-jsonschema#573 — `feat: cross-tree $ref support via --known-schema and --schema-package alias override`
15. omissis/go-jsonschema#574 — `feat: detect multi-type-union form, route through primitive wrapper`

The diff currently includes commits from earlier PRs in the stack because they aren't merged yet; once each lower PR lands, this PR's diff will automatically shrink to just its own contribution. No action needed on the contributor side between merges — GitHub recomputes the diff vs `main` after each merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enabled automated review triggers for pull requests targeting branches with prefixes feat/, fix/, docs/, and chore/ so matching PRs receive automatic reviews.
  * Added guidance for stacked-PR workflows and instructions for maintaining or extending the recognized base-branch prefix list.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/omissis/go-jsonschema/pull/563?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->