### PR TITLE
Support description as comment for enum type

### DIFF
--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -1337,6 +1337,7 @@ func (g *schemaGenerator) generateEnumType(
 		Name:       g.output.uniqueTypeName(scope),
 		Type:       enumType,
 		SchemaType: t,
+		Comment:    t.Description,
 	}
 	g.output.file.Package.AddDecl(&enumDecl)
 

--- a/tests/data/core/allOf/issue6.go
+++ b/tests/data/core/allOf/issue6.go
@@ -72,6 +72,7 @@ type Issue6Name struct {
 	Use_2 *Issue6NameUse_2 `json:"use,omitempty,omitzero" yaml:"use,omitempty" mapstructure:"use,omitempty"`
 }
 
+// Identifies the purpose for this name.
 type Issue6NameUse_2 string
 
 const Issue6NameUse_2_Anonymous Issue6NameUse_2 = "anonymous"

--- a/tests/data/regressions/issue427/issue427.go
+++ b/tests/data/regressions/issue427/issue427.go
@@ -129,6 +129,7 @@ type Testcase struct {
 	NotExpectedPeerName *TestcaseNotExpectedPeerName `json:"not_expected_peer_name,omitempty,omitzero" yaml:"not_expected_peer_name,omitempty" mapstructure:"not_expected_peer_name,omitempty"`
 }
 
+// Different types of peer subjects.
 type PeerKind string
 
 type TestcaseNotExpectedPeerName_0 = PeerName


### PR DESCRIPTION
This PR adds a simple passthrough of description of the type, into the enum type decl. 

While I do understand that it's less useful than individual comments, that is a bigger dialog that is not solved within the json-schema spec currently.

Example (enum inside object as `additionalProperties`):

```json
"additionalProperties": {
  "description": "THROTTLED is returned with X-Server-Protocol-Version 9 and later when the server is throttling the request.",
  "enum": [ "SUCCESS", "NOT_ACCESSIBLE", "FAILED", "THROTTLED" ]
}
```

Produces:

```go
// THROTTLED is returned with X-Server-Protocol-Version 9 and later when the server
// is throttling the request.
type AssignProfileResponseJsonDevicesValue string

const AssignProfileResponseJsonDevicesValueFAILED AssignProfileResponseJsonDevicesValue = "FAILED"
const AssignProfileResponseJsonDevicesValueNOTACCESSIBLE AssignProfileResponseJsonDevicesValue = "NOT_ACCESSIBLE"
const AssignProfileResponseJsonDevicesValueSUCCESS AssignProfileResponseJsonDevicesValue = "SUCCESS"
const AssignProfileResponseJsonDevicesValueTHROTTLED AssignProfileResponseJsonDevicesValue = "THROTTLED"
``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Generated enum declarations now retain their descriptions as comments, improving clarity in generated output.
* **Documentation**
  * Added inline comments in test fixture files to clarify the intent of specific types and sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->