### PR TITLE
chore: update goreleaser to v2.17.0

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -41,7 +41,7 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
-          version: 2.15.4
+          version: 2.17.0
           args: release --verbose --snapshot --clean
         env:
           GO_VERSION: 1.25.10

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
-          version: 2.15.4
+          version: 2.17.0
           args: release --verbose --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser
-          version: 2.15.4
+          version: 2.17.0
           args: release --verbose --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@
 adr-tools = "3.0.0"
 golang = "1.25.10"
 golangci-lint = "2.12.2"
-goreleaser = "2.15.4"
+goreleaser = "2.17.0"
 hadolint = "2.14.0"
 markdownlint-cli2 = "0.23.1"
 shellcheck = "0.11.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the GoReleaser tool to version 2.17.0 across development, prerelease, and release processes.
  * Aligned the configured local tooling version with the updated release automation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->