### PR TITLE
chore: update go to 1.25.12

### DIFF
--- a/.github/workflows/development.yaml
+++ b/.github/workflows/development.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: 1.25.10
+          go-version: 1.25.12
       - name: Setup workspace
         run: cp go.work.dist go.work
       - name: Download golangci-lint installer
@@ -44,4 +44,4 @@ jobs:
           version: 2.17.0
           args: release --verbose --snapshot --clean
         env:
-          GO_VERSION: 1.25.10
+          GO_VERSION: 1.25.12

--- a/.github/workflows/prerelease.yaml
+++ b/.github/workflows/prerelease.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: 1.25.10
+          go-version: 1.25.12
       - name: Setup workspace
         run: cp go.work.dist go.work
       - name: Create dedicated docker buildx builder instance
@@ -37,4 +37,4 @@ jobs:
           args: release --verbose --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          GO_VERSION: 1.25.10
+          GO_VERSION: 1.25.12

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Golang
         uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e # v7
         with:
-          go-version: 1.25.10
+          go-version: 1.25.12
       - name: Setup workspace
         run: cp go.work.dist go.work
       - name: Log in to Docker Hub
@@ -43,4 +43,4 @@ jobs:
           args: release --verbose --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          GO_VERSION: 1.25.10
+          GO_VERSION: 1.25.12

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25.10-alpine3.23 AS tools
+FROM golang:1.25.12-alpine3.23 AS tools
 
 ARG TARGETPLATFORM
 

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ SHELL := /bin/bash
 # ----------------------------------------------------------------------------------------------------------------------
 
 _DOCKER_FILELINT_IMAGE=cytopia/file-lint:latest-0.8
-_DOCKER_GOLANG_IMAGE=golang:1.25.10
+_DOCKER_GOLANG_IMAGE=golang:1.25.12
 _DOCKER_GOLANGCI_LINT_IMAGE=golangci/golangci-lint:v2.12.2
 _DOCKER_HADOLINT_IMAGE=hadolint/hadolint:v2.14.0
 _DOCKER_JSONLINT_IMAGE=cytopia/jsonlint:1.6

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/atombender/go-jsonschema
 
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.12
 
 require (
 	dario.cat/mergo v1.0.2

--- a/go.work.dist
+++ b/go.work.dist
@@ -1,6 +1,6 @@
 go 1.25.0
 
-toolchain go1.25.10
+toolchain go1.25.12
 
 use (
     .

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 
 adr-tools = "3.0.0"
-golang = "1.25.10"
+golang = "1.25.12"
 golangci-lint = "2.12.2"
 goreleaser = "2.17.0"
 hadolint = "2.14.0"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain to version 1.25.12.
  * Aligned development, prerelease, and release automation with the updated Go version.
  * Updated Docker-based build and development tooling to use Go 1.25.12.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->