### PR TITLE
Support loading schemas from embedded fs.FS

### DIFF
--- a/pkg/generator/schema_generator.go
+++ b/pkg/generator/schema_generator.go
@@ -121,7 +121,7 @@ func (g *schemaGenerator) generateReferencedType(t *schemas.Type) (codegen.Type,
 			return nil, fmt.Errorf("could not follow $ref %q to file %q: %w", t.Ref, fileName, serr)
 		}
 
-		qualified, qerr := schemas.QualifiedFileName(fileName, g.schemaFileName, g.config.ResolveExtensions)
+		qualified, qerr := schemas.ResolveRef(g.loader, fileName, g.schemaFileName, g.config.ResolveExtensions)
 		if qerr != nil {
 			return nil, fmt.Errorf("could not resolve qualified file name for %s: %w", fileName, qerr)
 		}

--- a/pkg/schemas/loaders.go
+++ b/pkg/schemas/loaders.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io/fs"
 	"net/http"
 	"net/url"
 	"os"
@@ -146,6 +147,87 @@ func (l *FileLoader) parseFile(fileName string) (*Schema, error) {
 	}
 
 	return sc, nil
+}
+
+// NewFSLoader is like NewFileLoader, but backed by a specified fs.FS.
+func NewFSLoader(fsys fs.FS, resolveExtensions, yamlExtensions []string) *FSLoader {
+	return &FSLoader{
+		fsys:              fsys,
+		resolveExtensions: resolveExtensions,
+		yamlExtensions:    toExtensionSet(yamlExtensions),
+	}
+}
+
+// FSLoader is like FileLoader, but loads schemas from a fs.FS, such as an
+// embed.FS.
+//
+// Schemas are identified by slash-separated, unrooted path names as defined by
+// fs.ValidPath, and references between schemas are resolved relative to the
+// directory of the referencing schema by implementing RefResolver.
+type FSLoader struct {
+	fsys              fs.FS
+	resolveExtensions []string
+	yamlExtensions    map[string]bool
+}
+
+func (l *FSLoader) Load(fileName, parentFileName string) (*Schema, error) {
+	qualified, err := l.ResolveRef(fileName, parentFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	f, err := l.fsys.Open(qualified)
+	if err != nil {
+		return nil, fmt.Errorf("error opening %s: %w", qualified, err)
+	}
+
+	defer func() {
+		_ = f.Close()
+	}()
+
+	if l.yamlExtensions[path.Ext(qualified)] {
+		sc, err := FromYAMLReader(f)
+		if err != nil {
+			return nil, fmt.Errorf("error parsing YAML file %s: %w", qualified, err)
+		}
+
+		return sc, nil
+	}
+
+	sc, err := FromJSONReader(f)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing JSON file %s: %w", qualified, err)
+	}
+
+	return sc, nil
+}
+
+func (l *FSLoader) ResolveRef(fileName, parentFileName string) (string, error) {
+	r, err := GetRefType(fileName)
+	if err != nil {
+		return "", err
+	}
+
+	if r != RefTypeFile {
+		return "", fmt.Errorf("%w: %q", ErrUnsupportedRefFormat, fileName)
+	}
+
+	fileName = strings.TrimPrefix(fileName, "file://")
+	qualified := path.Join(path.Dir(parentFileName), fileName)
+
+	exts := append([]string{""}, l.resolveExtensions...)
+	for _, ext := range exts {
+		candidate := qualified + ext
+		if !fs.ValidPath(candidate) {
+			continue
+		}
+
+		if _, err := fs.Stat(l.fsys, candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w %q", ErrCannotResolveSchema, fileName)
 }
 
 func NewDefaultCacheLoader(resolveExtensions, yamlExtensions []string) *CachedLoader {

--- a/pkg/schemas/loaders.go
+++ b/pkg/schemas/loaders.go
@@ -24,6 +24,54 @@ type Loader interface {
 	Load(uri, parentURI string) (*Schema, error)
 }
 
+// RefResolver allows a Loader to control how a schema ref is resolved to a
+// canonical name.
+//
+// When the generator follows a $ref from one schema file to another, it
+// resolves the referenced file name to a canonical name. The canonical name
+// identifies the loaded schema, and is used as the parent name when resolving
+// references made by the referenced schema in turn.
+//
+// By default, references are resolved against the native filesystem with
+// QualifiedFileName. Loaders that read schemas from somewhere other than the
+// native filesystem should implement RefResolver to resolve references in
+// their own namespace instead.
+type RefResolver interface {
+	// ResolveRef returns the canonical name of the fileName schema.
+	//
+	// parentFileName, if not empty, is the canonical name of the schema
+	// containing the reference.
+	ResolveRef(fileName, parentFileName string) (string, error)
+}
+
+// ResolveRef resolves fileName, referenced from the parentFileName schema,
+// to a canonical schema name.
+//
+// If loader (or a Loader it wraps, following any Unwrap methods) implements
+// RefResolver, resolution is delegated to it. Otherwise, fileName is resolved
+// against the native filesystem with QualifiedFileName using resolveExtensions.
+func ResolveRef(loader Loader, fileName, parentFileName string, resolveExtensions []string) (string, error) {
+	for l := loader; l != nil; {
+		if resolver, ok := l.(RefResolver); ok {
+			qualified, err := resolver.ResolveRef(fileName, parentFileName)
+			if err != nil {
+				return "", fmt.Errorf("failed to resolve schema reference %q: %w", fileName, err)
+			}
+
+			return qualified, nil
+		}
+
+		unwrapper, ok := l.(interface{ Unwrap() Loader })
+		if !ok {
+			break
+		}
+
+		l = unwrapper.Unwrap()
+	}
+
+	return QualifiedFileName(fileName, parentFileName, resolveExtensions)
+}
+
 func NewCachedLoader(loader Loader, cache map[string]*Schema) *CachedLoader {
 	return &CachedLoader{
 		loader: loader,
@@ -49,6 +97,11 @@ func (l *CachedLoader) Load(uri, parentURI string) (*Schema, error) {
 	l.cache[uri] = schema
 
 	return schema, nil
+}
+
+// Unwrap returns the Loader wrapped by l.
+func (l *CachedLoader) Unwrap() Loader {
+	return l.loader
 }
 
 func NewFileLoader(resolveExtensions, yamlExtensions []string) *FileLoader {

--- a/pkg/schemas/loaders_test.go
+++ b/pkg/schemas/loaders_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"testing/fstest"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -103,4 +104,77 @@ func (prefixResolverLoader) Load(_, _ string) (*schemas.Schema, error) {
 
 func (prefixResolverLoader) ResolveRef(fileName, parentFileName string) (string, error) {
 	return "resolved:" + parentFileName + ":" + fileName, nil
+}
+
+func TestFSLoader(t *testing.T) {
+	t.Parallel()
+
+	fsys := fstest.MapFS{
+		"schema.json": &fstest.MapFile{
+			Data: []byte(`{"$schema": "http://json-schema.org/draft-04/schema#", "id": "https://example.com/root"}`),
+		},
+		"sub/child.yaml": &fstest.MapFile{
+			Data: []byte("$schema: http://json-schema.org/draft-04/schema#\nid: https://example.com/child\n"),
+		},
+	}
+
+	// Construct a FSLoader backed by the fstest.MapFS in-memory FS.
+	loader := schemas.NewFSLoader(fsys, []string{".json"}, []string{".yaml"})
+
+	t.Run("loads JSON schemas", func(t *testing.T) {
+		t.Parallel()
+
+		schema, err := loader.Load("schema.json", "")
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com/root", schema.ID)
+	})
+
+	t.Run("loads YAML schemas relative to a parent schema", func(t *testing.T) {
+		t.Parallel()
+
+		schema, err := loader.Load("child.yaml", "sub/parent.json")
+		require.NoError(t, err)
+		assert.Equal(t, "https://example.com/child", schema.ID)
+	})
+
+	t.Run("resolves references relative to the parent schema", func(t *testing.T) {
+		t.Parallel()
+
+		qualified, err := loader.ResolveRef("../schema.json", "sub/child.yaml")
+		require.NoError(t, err)
+		assert.Equal(t, "schema.json", qualified)
+	})
+
+	t.Run("resolves extensions", func(t *testing.T) {
+		t.Parallel()
+
+		qualified, err := loader.ResolveRef("schema", "")
+		require.NoError(t, err)
+		assert.Equal(t, "schema.json", qualified)
+	})
+
+	t.Run("resolves references through a wrapping loader", func(t *testing.T) {
+		t.Parallel()
+
+		// Wrap the FSLoader in a CachedLoader. ResolveRef should still
+		// delegate to the FSLoader's RefResolver, not the native filesystem.
+		wrapped := schemas.NewCachedLoader(loader, map[string]*schemas.Schema{})
+		qualified, err := schemas.ResolveRef(wrapped, "schema", "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "schema.json", qualified)
+	})
+
+	t.Run("errors for unresolvable references", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loader.ResolveRef("missing.json", "")
+		assert.ErrorIs(t, err, schemas.ErrCannotResolveSchema)
+	})
+
+	t.Run("errors for non-file references", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := loader.ResolveRef("https://example.com/schema.json", "")
+		assert.ErrorIs(t, err, schemas.ErrUnsupportedRefFormat)
+	})
 }

--- a/pkg/schemas/loaders_test.go
+++ b/pkg/schemas/loaders_test.go
@@ -1,0 +1,106 @@
+package schemas_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/atombender/go-jsonschema/pkg/schemas"
+)
+
+func TestResolveRef(t *testing.T) {
+	t.Parallel()
+
+	t.Run("direct Loader implements RefResolver", func(t *testing.T) {
+		t.Parallel()
+
+		qualified, err := schemas.ResolveRef(prefixResolverLoader{}, "child.json", "parent.json", nil)
+
+		// We should get the prefix from the loader's RefResolver.
+		require.NoError(t, err)
+		assert.Equal(t, "resolved:parent.json:child.json", qualified)
+	})
+
+	t.Run("wrapped Loader implements RefResolver", func(t *testing.T) {
+		t.Parallel()
+
+		// Wrap the prefixResolverLoader in a CachedLoader
+		loader := schemas.NewCachedLoader(prefixResolverLoader{}, map[string]*schemas.Schema{})
+		qualified, err := schemas.ResolveRef(loader, "child.json", "parent.json", nil)
+
+		// We should still get the expected resolved: prefix from the wrapped
+		// loader's RefResolver.
+		require.NoError(t, err)
+		assert.Equal(t, "resolved:parent.json:child.json", qualified)
+	})
+
+	t.Run("multiply-wrapped Loader implements RefResolver", func(t *testing.T) {
+		t.Parallel()
+
+		// Wrap the prefixResolverLoader in a CachedLoader, and that in a
+		// passthroughLoader. Neither wrapper implements RefResolver.
+		loader := passthroughLoader{
+			wrapped: schemas.NewCachedLoader(prefixResolverLoader{}, map[string]*schemas.Schema{}),
+		}
+		qualified, err := schemas.ResolveRef(loader, "child.json", "parent.json", nil)
+
+		// ResolveRef should follow Unwrap through both layers to find the
+		// prefixResolverLoader's RefResolver.
+		require.NoError(t, err)
+		assert.Equal(t, "resolved:parent.json:child.json", qualified)
+	})
+
+	t.Run("no RefResolver falls back to the native filesystem", func(t *testing.T) {
+		t.Parallel()
+
+		dir := t.TempDir()
+		childPath := filepath.Join(dir, "child.json")
+		require.NoError(t, os.WriteFile(childPath, []byte("{}"), 0o600))
+
+		expected, err := filepath.EvalSymlinks(childPath)
+		require.NoError(t, err)
+
+		// Construct a FileLoader that doesn't implement RefResolver
+		loader := schemas.NewFileLoader([]string{".json"}, nil)
+
+		// We should get the expected filesystem qualified ref.
+		qualified, err := schemas.ResolveRef(loader, "child", filepath.Join(dir, "parent.json"), []string{".json"})
+		require.NoError(t, err)
+		assert.Equal(t, expected, qualified)
+	})
+}
+
+// passthroughLoader wraps another Loader, implementing Unwrap but not
+// RefResolver.
+type passthroughLoader struct {
+	wrapped schemas.Loader
+}
+
+func (l passthroughLoader) Load(fileName, parentFileName string) (*schemas.Schema, error) {
+	schema, err := l.wrapped.Load(fileName, parentFileName)
+	if err != nil {
+		return nil, fmt.Errorf("passthrough load of %s: %w", fileName, err)
+	}
+
+	return schema, nil
+}
+
+func (l passthroughLoader) Unwrap() schemas.Loader {
+	return l.wrapped
+}
+
+// prefixResolverLoader is an impl. of RefResolver that adds a 'resolved:'
+// prefix to the resolved name.
+type prefixResolverLoader struct{}
+
+func (prefixResolverLoader) Load(_, _ string) (*schemas.Schema, error) {
+	return &schemas.Schema{}, nil
+}
+
+func (prefixResolverLoader) ResolveRef(fileName, parentFileName string) (string, error) {
+	return "resolved:" + parentFileName + ":" + fileName, nil
+}

--- a/tests/generation_test.go
+++ b/tests/generation_test.go
@@ -2,6 +2,7 @@ package tests_test
 
 import (
 	"context"
+	"embed"
 	"errors"
 	"fmt"
 	"log"
@@ -121,6 +122,34 @@ func TestCrossPackage(t *testing.T) {
 	t.Parallel()
 
 	cfg := basicConfig
+	cfg.SchemaMappings = []generator.SchemaMapping{
+		{
+			SchemaID:    "https://example.com/schema",
+			PackageName: "github.com/atombender/go-jsonschema/tests/helpers/schema",
+			OutputName:  "schema.go",
+		},
+		{
+			SchemaID:    "https://example.com/other",
+			PackageName: "github.com/atombender/go-jsonschema/tests/data/crossPackage/other",
+			OutputName:  "../other/other.go",
+		},
+	}
+	testExampleFile(t, cfg, "./data/crossPackage/schema/schema.json")
+}
+
+//go:embed data/crossPackage
+var crossPackageFS embed.FS
+
+// TestCrossPackageFSLoader mirrors TestCrossPackage, but loads the schemas
+// from an embed.FS instead of the native filesystem.
+func TestCrossPackageFSLoader(t *testing.T) {
+	t.Parallel()
+
+	cfg := basicConfig
+	cfg.Loader = schemas.NewCachedLoader(
+		schemas.NewFSLoader(crossPackageFS, cfg.ResolveExtensions, cfg.YAMLExtensions),
+		map[string]*schemas.Schema{},
+	)
 	cfg.SchemaMappings = []generator.SchemaMapping{
 		{
 			SchemaID:    "https://example.com/schema",

--- a/tests/generation_test.go
+++ b/tests/generation_test.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"path"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -14,6 +15,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/atombender/go-jsonschema/pkg/generator"
+	"github.com/atombender/go-jsonschema/pkg/schemas"
 )
 
 var (
@@ -304,6 +306,101 @@ func TestStructWithConstraints(t *testing.T) {
 	testExamples(t, basicConfig, "./data/structWithConstraints")
 }
 
+func TestCustomLoaderRefResolution(t *testing.T) {
+	t.Parallel()
+
+	loader := memoryLoader{
+		"schema.json": `{
+			"$schema": "http://json-schema.org/draft-04/schema#",
+			"id": "https://example.com/parent",
+			"type": "object",
+			"properties": {
+				"child": {"$ref": "sub/child.json#/$defs/Child"}
+			}
+		}`,
+		"sub/child.json": `{
+			"$schema": "http://json-schema.org/draft-04/schema#",
+			"id": "https://example.com/child",
+			"$defs": {
+				"Child": {
+					"type": "object",
+					"properties": {
+						"grandchild": {"$ref": "grandchild.json#/$defs/Grandchild"}
+					}
+				}
+			}
+		}`,
+		"sub/grandchild.json": `{
+			"$schema": "http://json-schema.org/draft-04/schema#",
+			"id": "https://example.com/grandchild",
+			"$defs": {
+				"Grandchild": {
+					"type": "object",
+					"properties": {
+						"leaf": {"type": "boolean"}
+					}
+				}
+			}
+		}`,
+	}
+
+	// Build a CachedLoader wrapping a memoryLoader that implements
+	// RefResolver.
+	cfg := basicConfig
+	cfg.Loader = schemas.NewCachedLoader(loader, map[string]*schemas.Schema{})
+	cfg.SchemaMappings = []generator.SchemaMapping{
+		{
+			SchemaID:    "https://example.com/parent",
+			PackageName: "github.com/example/parent",
+			OutputName:  "parent.go",
+			RootType:    "Parent",
+		},
+		{
+			SchemaID:    "https://example.com/child",
+			PackageName: "github.com/example/child",
+			OutputName:  "child.go",
+		},
+		{
+			SchemaID:    "https://example.com/grandchild",
+			PackageName: "github.com/example/grandchild",
+			OutputName:  "grandchild.go",
+		},
+	}
+
+	g, err := generator.New(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// We should be able to generate code from the schema without error
+	// despite the fact that there is no filesystem representation of the
+	// data to consult for a naive ref resolution. The memoryLoader
+	// RefResolver must be used.
+	if err := g.DoFile("schema.json"); err != nil {
+		t.Fatal(err)
+	}
+
+	sources, err := g.Sources()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for outputName, decl := range map[string]string{
+		"parent.go":     "type Parent struct",
+		"child.go":      "type Child struct",
+		"grandchild.go": "type Grandchild struct",
+	} {
+		source, ok := sources[outputName]
+		if !ok {
+			t.Fatalf("Expected sources to contain %q", outputName)
+		}
+
+		if !strings.Contains(string(source), decl) {
+			t.Errorf("Expected %q to contain %q:\n%s", outputName, decl, source)
+		}
+	}
+}
+
 func testExamples(t *testing.T, cfg generator.Config, dataDir string) {
 	t.Helper()
 
@@ -468,4 +565,34 @@ func mustAbs(s string) string {
 	}
 
 	return result
+}
+
+// memoryLoader implements Loader and RefResolver, backed by a map.
+//
+// It loads schemas from an in-memory map of slash-separated schema
+// names to schema JSON, resolving references without touching the native
+// filesystem.
+type memoryLoader map[string]string
+
+func (l memoryLoader) Load(fileName, parentFileName string) (*schemas.Schema, error) {
+	qualified, err := l.ResolveRef(fileName, parentFileName)
+	if err != nil {
+		return nil, err
+	}
+
+	schema, err := schemas.FromJSONReader(strings.NewReader(l[qualified]))
+	if err != nil {
+		return nil, fmt.Errorf("error parsing %s: %w", qualified, err)
+	}
+
+	return schema, nil
+}
+
+func (l memoryLoader) ResolveRef(fileName, parentFileName string) (string, error) {
+	qualified := path.Join(path.Dir(parentFileName), fileName)
+	if _, ok := l[qualified]; !ok {
+		return "", fmt.Errorf("%w %q", schemas.ErrCannotResolveSchema, qualified)
+	}
+
+	return qualified, nil
 }


### PR DESCRIPTION
This branch adds support for generating code based on schema files provided by a stdlib [embedded filesystem](https://pkg.go.dev/embed#hdr-File_Systems). This is a convenient way for projects that are offered as a Go module to package schema content (for example, we use this approach in [c2sp/wycheproof](https://github.com/C2SP/wycheproof/blob/b61843a9a5115bb758134b6a1f5d5e502d445342/testvectors.go#L18-L21)).

Today it's not sufficient to implement a custom `Loader` backed by an `fs.FS` instance because to determine qualified schema names when processing references the existing code unconditionally consults the native FS (see #495). To work around this in a backwards compatible way this branch introduces a companion `RefResolver` interface alongside `Loader` that can be used to customize how refs are resolved to qualified schema names when schemas come from a custom datasource. To support the use-case where it's a wrapped loaded that implements `RefResolver` we add a `CachedLoader.Unwrap()` to the one first-party wrapper and chase similar `Unwrap()`'s across custom impls.

With these pieces in place we can offer a `schemas.NewFSLoader()` constructor to complement `schemas.NewFileLoader()` that consumes a `fs.FS`, implementing `Loader` and `RefResolver` for it. You can see an end-to-end demonstration of using the new `FSLoader` type in this [Go stdlib WIP CR](https://go-review.googlesource.com/c/go/+/809480) where we consume the Wycheproof schema `fs.FS` directly in order to generate the vendored Go code without needing an intermediate round-trip to the native filesystem.

Resolves https://github.com/omissis/go-jsonschema/issues/495

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added filesystem-based schema loading for JSON and YAML files.
  * Added support for resolving relative and cross-file schema references, including nested references and configurable extensions.
  * Improved compatibility with cached and wrapped schema loaders.

* **Bug Fixes**
  * Cross-file schema references now resolve consistently during code generation.

* **Tests**
  * Added coverage for filesystem loading, nested references, caching, extension resolution, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->